### PR TITLE
fix: fetch updates when navigating calendar months

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,6 @@ import { PageSpinner } from "@/components/ui/page-spinner";
 import type { UpdateData } from "@/types";
 
 export default function UpdatesPage() {
-  const [updateCount, setUpdateCount] = useState(0);
   const [streak, setStreak] = useState(0);
   const [monthUpdates, setMonthUpdates] = useState<UpdateData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -25,7 +24,6 @@ export default function UpdatesPage() {
       .then(([monthData, allData]) => {
         const mUpdates: UpdateData[] = monthData.updates || [];
         setMonthUpdates(mUpdates);
-        setUpdateCount(mUpdates.length);
 
         // Calculate streak client-side
         const allUpdates: UpdateData[] = allData.updates || [];
@@ -66,7 +64,6 @@ export default function UpdatesPage() {
 
   return (
     <UpdatesPageClient
-      updateCount={updateCount}
       streak={streak}
       monthUpdates={monthUpdates}
     />

--- a/src/components/updates/calendar.tsx
+++ b/src/components/updates/calendar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useCalendar } from "@/hooks/use-calendar";
 import { Button } from "@/components/ui/button";
 import type { CombinedStatus } from "@/types";
 
@@ -15,10 +14,15 @@ const STATUS_STYLES: Record<CombinedStatus, string> = {
 interface CalendarProps {
   updateStatusMap: Map<string, CombinedStatus>;
   onDayClick: (date: Date) => void;
+  monthTitle: string;
+  calendarDays: Array<{ day: number; isCurrentMonth: boolean; isToday: boolean; date: Date }>;
+  prevMonth: () => void;
+  nextMonth: () => void;
+  goToToday: () => void;
+  loading?: boolean;
 }
 
-export function Calendar({ updateStatusMap, onDayClick }: CalendarProps) {
-  const { monthTitle, calendarDays, prevMonth, nextMonth, goToToday } = useCalendar();
+export function Calendar({ updateStatusMap, onDayClick, monthTitle, calendarDays, prevMonth, nextMonth, goToToday, loading }: CalendarProps) {
 
   const getUpdateStatus = (date: Date): CombinedStatus | null => {
     const key = date.toLocaleDateString("sv-SE");
@@ -55,7 +59,7 @@ export function Calendar({ updateStatusMap, onDayClick }: CalendarProps) {
         ))}
       </div>
 
-      <div className="grid grid-cols-7 gap-1.5 flex-1 auto-rows-fr">
+      <div className={`grid grid-cols-7 gap-1.5 flex-1 auto-rows-fr transition-opacity duration-200 ${loading ? "opacity-40 pointer-events-none" : ""}`}>
         {calendarDays.map((day, i) => {
           const isWeekend = day.date.getDay() === 0 || day.date.getDay() === 6;
           const status = day.isCurrentMonth ? getUpdateStatus(day.date) : null;

--- a/src/components/updates/updates-page-client.tsx
+++ b/src/components/updates/updates-page-client.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { StatsBar } from "./stats-bar";
 import { Calendar } from "./calendar";
 import { HistoryDetailModal } from "@/components/history/history-detail-modal";
 import { useAppStore } from "@/stores/app-store";
+import { useCalendar } from "@/hooks/use-calendar";
+import { authedFetch } from "@/lib/api-client";
 import { computeCombinedStatus } from "@/types";
 import type { CombinedStatus, StatData, UpdateData } from "@/types";
+
+function formatMonth(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+}
 
 interface Props {
   updateCount: number;
@@ -16,11 +22,43 @@ interface Props {
 }
 
 export function UpdatesPageClient({
-  updateCount,
   streak,
   monthUpdates: initialMonthUpdates,
 }: Props) {
+  const { currentMonth, monthTitle, calendarDays, prevMonth, nextMonth, goToToday } = useCalendar();
   const [monthUpdates, setMonthUpdates] = useState(initialMonthUpdates);
+  const [monthLoading, setMonthLoading] = useState(false);
+  const initialMonthRef = useRef<string>(formatMonth(new Date()));
+
+  useEffect(() => {
+    const monthStr = formatMonth(currentMonth);
+    if (monthStr === initialMonthRef.current && monthUpdates === initialMonthUpdates) {
+      return; // skip fetch on mount — we already have initial data
+    }
+
+    const controller = new AbortController();
+    setMonthLoading(true);
+    authedFetch(`/api/updates?month=${monthStr}`, { signal: controller.signal })
+      .then((r) => r.json())
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setMonthUpdates(data.updates || []);
+        }
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          console.error("[Narada] Failed to fetch month updates:", err);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setMonthLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [currentMonth]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const updateStatusMap = useMemo(() => {
     const map = new Map<string, CombinedStatus>();
     for (const u of monthUpdates) {
@@ -42,8 +80,8 @@ export function UpdatesPageClient({
 
   const stats: StatData[] = [
     {
-      label: "Messages This Month",
-      value: updateCount,
+      label: "Scrolls This Month",
+      value: monthUpdates.length,
       icon: "\u{1F4CA}",
       color: "blue",
     },
@@ -55,7 +93,7 @@ export function UpdatesPageClient({
     },
     {
       label: "Time Reclaimed",
-      value: `${updateCount * 12}m`,
+      value: `${monthUpdates.length * 12}m`,
       icon: "\u23F1\uFE0F",
       color: "emerald",
     },
@@ -90,7 +128,16 @@ export function UpdatesPageClient({
   return (
     <div className="flex-1 flex flex-col overflow-hidden p-6">
       <div className="flex-shrink-0"><StatsBar stats={stats} /></div>
-      <Calendar updateStatusMap={updateStatusMap} onDayClick={handleDayClick} />
+      <Calendar
+        updateStatusMap={updateStatusMap}
+        onDayClick={handleDayClick}
+        monthTitle={monthTitle}
+        calendarDays={calendarDays}
+        prevMonth={prevMonth}
+        nextMonth={nextMonth}
+        goToToday={goToToday}
+        loading={monthLoading}
+      />
       <p className="mt-auto pt-4 pb-2 text-center text-xs text-white/20">v{process.env.NEXT_PUBLIC_APP_VERSION}</p>
 
       {selectedUpdate && (

--- a/src/components/updates/updates-page-client.tsx
+++ b/src/components/updates/updates-page-client.tsx
@@ -16,7 +16,6 @@ function formatMonth(date: Date): string {
 }
 
 interface Props {
-  updateCount: number;
   streak: number;
   monthUpdates: UpdateData[];
 }
@@ -80,7 +79,7 @@ export function UpdatesPageClient({
 
   const stats: StatData[] = [
     {
-      label: "Scrolls This Month",
+      label: "Messages This Month",
       value: monthUpdates.length,
       icon: "\u{1F4CA}",
       color: "blue",

--- a/src/components/updates/updates-page-client.tsx
+++ b/src/components/updates/updates-page-client.tsx
@@ -27,16 +27,18 @@ export function UpdatesPageClient({
   const { currentMonth, monthTitle, calendarDays, prevMonth, nextMonth, goToToday } = useCalendar();
   const [monthUpdates, setMonthUpdates] = useState(initialMonthUpdates);
   const [monthLoading, setMonthLoading] = useState(false);
-  const initialMonthRef = useRef<string>(formatMonth(new Date()));
+  const hasNavigated = useRef(false);
 
   useEffect(() => {
-    const monthStr = formatMonth(currentMonth);
-    if (monthStr === initialMonthRef.current && monthUpdates === initialMonthUpdates) {
+    if (!hasNavigated.current) {
+      hasNavigated.current = true;
       return; // skip fetch on mount — we already have initial data
     }
 
     const controller = new AbortController();
     setMonthLoading(true);
+    setMonthUpdates([]);
+    const monthStr = formatMonth(currentMonth);
     authedFetch(`/api/updates?month=${monthStr}`, { signal: controller.signal })
       .then((r) => r.json())
       .then((data) => {
@@ -56,7 +58,7 @@ export function UpdatesPageClient({
       });
 
     return () => controller.abort();
-  }, [currentMonth]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currentMonth]);
 
   const updateStatusMap = useMemo(() => {
     const map = new Map<string, CombinedStatus>();


### PR DESCRIPTION
## Summary
- **Root cause:** The home page calendar fetched updates only for the current month on initial load and never refetched when users navigated to previous/next months — making old entries appear missing
- **Fix:** Lifted `useCalendar` hook from `Calendar` into `UpdatesPageClient` so month navigation triggers an API fetch with `AbortController` for race-condition safety
- **Cleanup:** Removed unused `updateCount` prop; stats now derive from fetched data dynamically

Closes #8

## Test plan
- [ ] Navigate to a previous month with known updates — indicators should appear after brief loading
- [ ] Navigate back to current month — indicators still correct
- [ ] Rapid month navigation (click arrows quickly) — no stale data displayed
- [ ] Click a day with an update in a past month — detail modal opens correctly
- [ ] Stats ("Messages This Month", "Time Reclaimed") update to reflect the viewed month

🤖 Generated with [Claude Code](https://claude.ai/claude-code)