### PR TITLE
feat: OpenAI + Azure OpenAI providers with admin-managed global keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "narada-app",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "narada-app",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
@@ -25,6 +25,7 @@
         "lucide-react": "^0.563.0",
         "next": "16.1.6",
         "node-schedule": "^2.1.1",
+        "openai": "^6.39.1",
         "parse-duration": "^2.1.5",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
@@ -15290,6 +15291,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.39.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.1.tgz",
+      "integrity": "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "node-schedule": "^2.1.1",
+    "openai": "^6.39.1",
     "parse-duration": "^2.1.5",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AdminSettingsClient } from "@/components/admin/admin-settings-client";
+
+export default function AdminSettingsPage() {
+  return <AdminSettingsClient />;
+}

--- a/src/app/api/admin/config/ai-provider/route.ts
+++ b/src/app/api/admin/config/ai-provider/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/admin-auth";
+import { handleAuthError } from "@/lib/auth-middleware";
+import {
+  GLOBAL_AI_DOC_REF,
+  getGlobalAIConfig,
+  invalidateGlobalAIConfig,
+  maskedGlobalConfig,
+  MASKED_PLACEHOLDER,
+  type AzureOpenAIGlobalConfig,
+  type GlobalAIProviderConfig,
+  type OpenAIGlobalConfig,
+  type SingleKeyGlobalConfig,
+} from "@/lib/global-ai-config";
+
+function isString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function isReplacementKey(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0 && !v.includes(MASKED_PLACEHOLDER);
+}
+
+interface IncomingPayload {
+  claudeApi?: { apiKey?: string | null } | null;
+  gemini?: { apiKey?: string | null } | null;
+  groq?: { apiKey?: string | null } | null;
+  openai?: { apiKey?: string | null; model?: string | null; baseUrl?: string | null } | null;
+  azureOpenai?: {
+    apiKey?: string | null;
+    endpoint?: string | null;
+    deployment?: string | null;
+    apiVersion?: string | null;
+  } | null;
+  removeProviders?: string[];
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    await verifyAdmin(request);
+    const config = await getGlobalAIConfig();
+    return NextResponse.json(maskedGlobalConfig(config));
+  } catch (error) {
+    return handleAuthError(error);
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const admin = await verifyAdmin(request);
+    const body = (await request.json()) as IncomingPayload;
+
+    const existing = await getGlobalAIConfig();
+    const next: GlobalAIProviderConfig = { ...existing };
+
+    if (body.claudeApi !== undefined && body.claudeApi !== null) {
+      const apiKey = body.claudeApi.apiKey;
+      if (isReplacementKey(apiKey)) {
+        next.claudeApi = { apiKey } satisfies SingleKeyGlobalConfig;
+      }
+    }
+    if (body.gemini !== undefined && body.gemini !== null) {
+      const apiKey = body.gemini.apiKey;
+      if (isReplacementKey(apiKey)) {
+        next.gemini = { apiKey } satisfies SingleKeyGlobalConfig;
+      }
+    }
+    if (body.groq !== undefined && body.groq !== null) {
+      const apiKey = body.groq.apiKey;
+      if (isReplacementKey(apiKey)) {
+        next.groq = { apiKey } satisfies SingleKeyGlobalConfig;
+      }
+    }
+    if (body.openai !== undefined && body.openai !== null) {
+      const prev = next.openai ?? null;
+      const apiKey = isReplacementKey(body.openai.apiKey)
+        ? body.openai.apiKey
+        : prev?.apiKey;
+      const model = isString(body.openai.model) ? body.openai.model : prev?.model;
+      const baseUrl = isString(body.openai.baseUrl) ? body.openai.baseUrl : prev?.baseUrl;
+      if (apiKey) {
+        next.openai = { apiKey, model, baseUrl } satisfies OpenAIGlobalConfig;
+      }
+    }
+    if (body.azureOpenai !== undefined && body.azureOpenai !== null) {
+      const prev = next.azureOpenai ?? null;
+      const apiKey = isReplacementKey(body.azureOpenai.apiKey)
+        ? body.azureOpenai.apiKey
+        : prev?.apiKey;
+      const endpoint = isString(body.azureOpenai.endpoint)
+        ? body.azureOpenai.endpoint
+        : prev?.endpoint;
+      const deployment = isString(body.azureOpenai.deployment)
+        ? body.azureOpenai.deployment
+        : prev?.deployment;
+      const apiVersion = isString(body.azureOpenai.apiVersion)
+        ? body.azureOpenai.apiVersion
+        : prev?.apiVersion ?? "2024-08-01-preview";
+      if (apiKey && endpoint && deployment && apiVersion) {
+        next.azureOpenai = {
+          apiKey,
+          endpoint,
+          deployment,
+          apiVersion,
+        } satisfies AzureOpenAIGlobalConfig;
+      }
+    }
+
+    if (Array.isArray(body.removeProviders)) {
+      for (const key of body.removeProviders) {
+        if (key === "claudeApi") delete next.claudeApi;
+        else if (key === "gemini") delete next.gemini;
+        else if (key === "groq") delete next.groq;
+        else if (key === "openai") delete next.openai;
+        else if (key === "azureOpenai") delete next.azureOpenai;
+      }
+    }
+
+    next.updatedAt = Date.now();
+    next.updatedBy = admin.uid;
+
+    await GLOBAL_AI_DOC_REF().set(next, { merge: false });
+    invalidateGlobalAIConfig();
+
+    return NextResponse.json(maskedGlobalConfig(next));
+  } catch (error) {
+    return handleAuthError(error);
+  }
+}

--- a/src/app/api/settings/ai-provider/route.ts
+++ b/src/app/api/settings/ai-provider/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAuth, isAuthError, handleAuthError } from "@/lib/auth-middleware";
 import { settingsDoc } from "@/lib/firestore-helpers";
-import type { AIProvider } from "@/types";
+import type { AIProvider, KeyProvider } from "@/types";
+import type { UseGlobalFor } from "@/lib/ai";
 
-const VALID_PROVIDERS: AIProvider[] = ["gemini", "claude-api", "local-claude", "local-cursor", "groq"];
+const VALID_PROVIDERS: AIProvider[] = [
+  "gemini",
+  "claude-api",
+  "local-claude",
+  "local-cursor",
+  "groq",
+  "openai",
+  "azure-openai",
+];
 const MASKED = "••••••••";
 
 function maskKey(key: string | null | undefined): string {
@@ -18,19 +27,59 @@ interface StoredSettings {
   claudeApiKey?: string | null;
   deepgramApiKey?: string | null;
   groqApiKey?: string | null;
+  openaiApiKey?: string | null;
+  azureOpenaiApiKey?: string | null;
+  azureOpenaiEndpoint?: string | null;
+  azureOpenaiDeployment?: string | null;
+  azureOpenaiApiVersion?: string | null;
+  useGlobalFor?: UseGlobalFor;
+}
+
+const REMOVABLE_FIELDS = [
+  "geminiApiKey",
+  "claudeApiKey",
+  "deepgramApiKey",
+  "groqApiKey",
+  "openaiApiKey",
+  "azureOpenaiApiKey",
+  "azureOpenaiEndpoint",
+  "azureOpenaiDeployment",
+  "azureOpenaiApiVersion",
+] as const;
+
+function normalizeUseGlobalFor(input: unknown): UseGlobalFor | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const src = input as Record<string, unknown>;
+  const keys: KeyProvider[] = ["claude-api", "gemini", "groq", "openai", "azure-openai"];
+  const out: UseGlobalFor = {};
+  for (const k of keys) {
+    if (typeof src[k] === "boolean") out[k] = src[k] as boolean;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function buildSettingsResponse(settings: StoredSettings | undefined) {
+  const useGlobalFor: UseGlobalFor = settings?.useGlobalFor ?? {};
   return {
     aiProvider: settings?.aiProvider ?? "local-claude",
     geminiApiKey: maskKey(settings?.geminiApiKey),
     claudeApiKey: maskKey(settings?.claudeApiKey),
     deepgramApiKey: maskKey(settings?.deepgramApiKey),
     groqApiKey: maskKey(settings?.groqApiKey),
+    openaiApiKey: maskKey(settings?.openaiApiKey),
+    azureOpenaiApiKey: maskKey(settings?.azureOpenaiApiKey),
+    azureOpenaiEndpoint: settings?.azureOpenaiEndpoint ?? "",
+    azureOpenaiDeployment: settings?.azureOpenaiDeployment ?? "",
+    azureOpenaiApiVersion: settings?.azureOpenaiApiVersion ?? "",
     hasGeminiKey: !!settings?.geminiApiKey,
     hasClaudeKey: !!settings?.claudeApiKey,
     hasDeepgramKey: !!settings?.deepgramApiKey,
     hasGroqKey: !!settings?.groqApiKey,
+    hasOpenaiKey: !!settings?.openaiApiKey,
+    hasAzureOpenaiKey: !!settings?.azureOpenaiApiKey,
+    hasAzureOpenaiEndpoint: !!settings?.azureOpenaiEndpoint,
+    hasAzureOpenaiDeployment: !!settings?.azureOpenaiDeployment,
+    useGlobalFor,
   };
 }
 
@@ -47,12 +96,38 @@ export async function GET(request: NextRequest) {
   }
 }
 
+function applyKeyField(updateData: Record<string, unknown>, key: string, value: unknown) {
+  if (typeof value !== "string") return;
+  if (!value) return;
+  if (value.includes(MASKED)) return;
+  updateData[key] = value;
+}
+
+function applyPlainField(updateData: Record<string, unknown>, key: string, value: unknown) {
+  if (typeof value !== "string") return;
+  if (!value) return;
+  updateData[key] = value;
+}
+
 export async function PUT(request: NextRequest) {
   try {
     const user = await verifyAuth(request);
     console.log(`[Narada] PUT /api/settings/ai-provider uid=${user.uid}`);
     const body = await request.json();
-    const { aiProvider, geminiApiKey, claudeApiKey, deepgramApiKey, groqApiKey, removeKeys } = body;
+    const {
+      aiProvider,
+      geminiApiKey,
+      claudeApiKey,
+      deepgramApiKey,
+      groqApiKey,
+      openaiApiKey,
+      azureOpenaiApiKey,
+      azureOpenaiEndpoint,
+      azureOpenaiDeployment,
+      azureOpenaiApiVersion,
+      useGlobalFor,
+      removeKeys,
+    } = body;
 
     if (aiProvider && !VALID_PROVIDERS.includes(aiProvider)) {
       return NextResponse.json(
@@ -61,16 +136,30 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const updateData: Record<string, string | null> = {};
+    const updateData: Record<string, unknown> = {};
     if (aiProvider) updateData.aiProvider = aiProvider;
-    if (geminiApiKey && !geminiApiKey.includes(MASKED)) updateData.geminiApiKey = geminiApiKey;
-    if (claudeApiKey && !claudeApiKey.includes(MASKED)) updateData.claudeApiKey = claudeApiKey;
-    if (deepgramApiKey && !deepgramApiKey.includes(MASKED)) updateData.deepgramApiKey = deepgramApiKey;
-    if (groqApiKey && !groqApiKey.includes(MASKED)) updateData.groqApiKey = groqApiKey;
+
+    applyKeyField(updateData, "geminiApiKey", geminiApiKey);
+    applyKeyField(updateData, "claudeApiKey", claudeApiKey);
+    applyKeyField(updateData, "deepgramApiKey", deepgramApiKey);
+    applyKeyField(updateData, "groqApiKey", groqApiKey);
+    applyKeyField(updateData, "openaiApiKey", openaiApiKey);
+    applyKeyField(updateData, "azureOpenaiApiKey", azureOpenaiApiKey);
+
+    applyPlainField(updateData, "azureOpenaiEndpoint", azureOpenaiEndpoint);
+    applyPlainField(updateData, "azureOpenaiDeployment", azureOpenaiDeployment);
+    applyPlainField(updateData, "azureOpenaiApiVersion", azureOpenaiApiVersion);
+
+    const normalizedUseGlobalFor = normalizeUseGlobalFor(useGlobalFor);
+    if (normalizedUseGlobalFor) {
+      const existingDoc = await settingsDoc(user.uid).get();
+      const existing = (existingDoc.data() as StoredSettings | undefined)?.useGlobalFor ?? {};
+      updateData.useGlobalFor = { ...existing, ...normalizedUseGlobalFor };
+    }
 
     const keysToRemove: string[] = Array.isArray(removeKeys) ? removeKeys : [];
     for (const key of keysToRemove) {
-      if (["geminiApiKey", "claudeApiKey", "deepgramApiKey", "groqApiKey"].includes(key)) {
+      if ((REMOVABLE_FIELDS as readonly string[]).includes(key)) {
         updateData[key] = null;
       }
     }

--- a/src/app/api/settings/global-ai-status/route.ts
+++ b/src/app/api/settings/global-ai-status/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAuth, isAuthError, handleAuthError } from "@/lib/auth-middleware";
+import { getGlobalAIConfig, globalKeyStatusFlags } from "@/lib/global-ai-config";
+
+export async function GET(request: NextRequest) {
+  try {
+    await verifyAuth(request);
+    const config = await getGlobalAIConfig();
+    return NextResponse.json(globalKeyStatusFlags(config));
+  } catch (error) {
+    if (isAuthError(error)) return handleAuthError(error);
+    console.error("[Narada] GET /api/settings/global-ai-status failed:", error);
+    return NextResponse.json({ error: "Failed to fetch global AI status" }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/test-ai/route.ts
+++ b/src/app/api/settings/test-ai/route.ts
@@ -2,21 +2,68 @@ import { NextRequest, NextResponse } from "next/server";
 import { spawn } from "child_process";
 import { verifyAuth, isAuthError, handleAuthError } from "@/lib/auth-middleware";
 import { settingsDoc } from "@/lib/firestore-helpers";
-import type { AIProvider } from "@/types";
+import { resolveProviderConfig, type AppSettings } from "@/lib/ai";
+import { getGlobalAIConfig } from "@/lib/global-ai-config";
+import type { AIProvider, KeyProvider } from "@/types";
 
-const VALID_PROVIDERS: AIProvider[] = ["gemini", "claude-api", "local-claude", "local-cursor", "groq"];
+const VALID_PROVIDERS: AIProvider[] = [
+  "gemini",
+  "claude-api",
+  "local-claude",
+  "local-cursor",
+  "groq",
+  "openai",
+  "azure-openai",
+];
 const CLI_TIMEOUT_MS = 15_000;
+const MASKED = "••••••••";
+
+const KEY_PROVIDERS = new Set<AIProvider>([
+  "gemini",
+  "claude-api",
+  "groq",
+  "openai",
+  "azure-openai",
+]);
+
+function isKeyProvider(p: AIProvider): p is KeyProvider {
+  return KEY_PROVIDERS.has(p);
+}
+
+/** Treat masked/empty values from the form as "no override". */
+function pickOverride(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  if (!v) return undefined;
+  if (v.includes(MASKED)) return undefined;
+  return v;
+}
 
 export async function POST(request: NextRequest) {
   try {
     const user = await verifyAuth(request);
     const body = await request.json();
-    const { provider, geminiApiKey, claudeApiKey, groqApiKey, useStoredKey } = body as {
+    const {
+      provider,
+      geminiApiKey,
+      claudeApiKey,
+      groqApiKey,
+      openaiApiKey,
+      azureOpenaiApiKey,
+      azureOpenaiEndpoint,
+      azureOpenaiDeployment,
+      azureOpenaiApiVersion,
+      useGlobal,
+    } = body as {
       provider: AIProvider;
       geminiApiKey?: string;
       claudeApiKey?: string;
       groqApiKey?: string;
-      useStoredKey?: boolean;
+      openaiApiKey?: string;
+      azureOpenaiApiKey?: string;
+      azureOpenaiEndpoint?: string;
+      azureOpenaiDeployment?: string;
+      azureOpenaiApiVersion?: string;
+      useGlobal?: boolean;
     };
 
     if (!provider || !VALID_PROVIDERS.includes(provider)) {
@@ -26,34 +73,61 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    switch (provider) {
+    if (provider === "local-claude") {
+      await spawnTest("claude", [
+        "--print", "--no-session-persistence", "--model", "sonnet",
+        "--max-budget-usd", "0.01", "Say hello in one word",
+      ]);
+      return NextResponse.json({ success: true });
+    }
+
+    if (provider === "local-cursor") {
+      await spawnTest("agent", ["--trust", "-p", "Say hello in one word"]);
+      return NextResponse.json({ success: true });
+    }
+
+    if (!isKeyProvider(provider)) {
+      return NextResponse.json({ success: false, error: "Unsupported provider" }, { status: 400 });
+    }
+
+    // Always start from the user's stored settings, then overlay any form
+    // values the request provided. Masked / blank values from the form are
+    // treated as "no override" so the stored secret is preserved.
+    const snap = await settingsDoc(user.uid).get();
+    const stored = (snap.data() ?? {}) as Record<string, string | undefined>;
+
+    const settings: AppSettings = {
+      geminiApiKey: pickOverride(geminiApiKey) ?? stored.geminiApiKey,
+      claudeApiKey: pickOverride(claudeApiKey) ?? stored.claudeApiKey,
+      groqApiKey: pickOverride(groqApiKey) ?? stored.groqApiKey,
+      openaiApiKey: pickOverride(openaiApiKey) ?? stored.openaiApiKey,
+      azureOpenaiApiKey: pickOverride(azureOpenaiApiKey) ?? stored.azureOpenaiApiKey,
+      azureOpenaiEndpoint:
+        pickOverride(azureOpenaiEndpoint) ?? stored.azureOpenaiEndpoint,
+      azureOpenaiDeployment:
+        pickOverride(azureOpenaiDeployment) ?? stored.azureOpenaiDeployment,
+      azureOpenaiApiVersion:
+        pickOverride(azureOpenaiApiVersion) ?? stored.azureOpenaiApiVersion,
+    };
+
+    if (useGlobal) {
+      settings.useGlobalFor = { [provider]: true };
+    }
+
+    const global = await getGlobalAIConfig();
+    const resolved = resolveProviderConfig(provider, settings, global);
+
+    switch (resolved.kind) {
       case "gemini": {
-        let apiKey = geminiApiKey;
-        if (useStoredKey) {
-          const snap = await settingsDoc(user.uid).get();
-          apiKey = snap.data()?.geminiApiKey ?? undefined;
-        }
-        if (!apiKey) {
-          return NextResponse.json({ success: false, error: "No Gemini API key provided" }, { status: 400 });
-        }
         const { GoogleGenerativeAI } = await import("@google/generative-ai");
-        const genAI = new GoogleGenerativeAI(apiKey);
+        const genAI = new GoogleGenerativeAI(resolved.apiKey);
         const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
         await model.generateContent("Say hello in one word");
         break;
       }
-
       case "claude-api": {
-        let apiKey = claudeApiKey;
-        if (useStoredKey) {
-          const snap = await settingsDoc(user.uid).get();
-          apiKey = snap.data()?.claudeApiKey ?? undefined;
-        }
-        if (!apiKey) {
-          return NextResponse.json({ success: false, error: "No Anthropic API key provided" }, { status: 400 });
-        }
         const { default: Anthropic } = await import("@anthropic-ai/sdk");
-        const client = new Anthropic({ apiKey });
+        const client = new Anthropic({ apiKey: resolved.apiKey });
         await client.messages.create({
           model: "claude-sonnet-4-20250514",
           max_tokens: 10,
@@ -61,36 +135,48 @@ export async function POST(request: NextRequest) {
         });
         break;
       }
-
-      case "local-claude": {
-        await spawnTest("claude", [
-          "--print", "--no-session-persistence", "--model", "sonnet",
-          "--max-budget-usd", "0.01", "Say hello in one word",
-        ]);
-        break;
-      }
-
-      case "local-cursor": {
-        await spawnTest("agent", ["--trust", "-p", "Say hello in one word"]);
-        break;
-      }
-
       case "groq": {
-        let apiKey = groqApiKey;
-        if (useStoredKey) {
-          const snap = await settingsDoc(user.uid).get();
-          apiKey = snap.data()?.groqApiKey ?? undefined;
-        }
-        if (!apiKey) {
-          return NextResponse.json({ success: false, error: "No Groq API key provided" }, { status: 400 });
-        }
         const { default: Groq } = await import("groq-sdk");
         const { GROQ_MODEL } = await import("@/lib/ai/groq-provider");
-        const client = new Groq({ apiKey, timeout: 15_000 });
+        const client = new Groq({ apiKey: resolved.apiKey, timeout: 15_000 });
         await client.chat.completions.create({
           model: GROQ_MODEL,
           messages: [{ role: "user", content: "Say hello in one word" }],
           max_tokens: 10,
+        });
+        break;
+      }
+      case "openai": {
+        const { default: OpenAI } = await import("openai");
+        const { DEFAULT_OPENAI_MODEL } = await import("@/lib/ai/openai-provider");
+        const client = new OpenAI({
+          apiKey: resolved.apiKey,
+          baseURL: resolved.baseUrl || undefined,
+          timeout: 15_000,
+        });
+        await client.chat.completions.create({
+          model: resolved.model || DEFAULT_OPENAI_MODEL,
+          messages: [{ role: "user", content: "Say hello in one word" }],
+          max_completion_tokens: 16,
+        });
+        break;
+      }
+      case "azure-openai": {
+        const { AzureOpenAI } = await import("openai");
+        const client = new AzureOpenAI({
+          apiKey: resolved.apiKey,
+          endpoint: resolved.endpoint,
+          deployment: resolved.deployment,
+          apiVersion: resolved.apiVersion,
+          timeout: 15_000,
+        });
+        console.log(
+          `[Test AI → Azure] endpoint=${resolved.endpoint} deployment=${resolved.deployment} apiVersion=${resolved.apiVersion}`
+        );
+        await client.chat.completions.create({
+          model: resolved.deployment,
+          messages: [{ role: "user", content: "Say hello in one word" }],
+          max_completion_tokens: 16,
         });
         break;
       }

--- a/src/components/admin/admin-settings-client.tsx
+++ b/src/components/admin/admin-settings-client.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { authedFetch } from "@/lib/api-client";
+import { PageSpinner } from "@/components/ui/page-spinner";
+import { GlobalAIOracleCard } from "./global-ai-oracle-card";
+
+export function AdminSettingsClient() {
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    authedFetch("/api/admin/check")
+      .then((r) => r.json())
+      .then((d) => setAllowed(!!d.isAdmin))
+      .catch(() => setAllowed(false));
+  }, []);
+
+  if (allowed === null) {
+    return <PageSpinner message="The sage verifies your standing..." />;
+  }
+
+  if (!allowed) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="glass-card p-8 text-center max-w-md">
+          <p className="text-xl narada-text mb-2">Narayan Narayan!</p>
+          <p className="narada-text-secondary">
+            Only the highest sages may enter the sanctum.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold narada-text">Sacred Sanctum</h1>
+        <p className="text-sm narada-text-secondary mt-1">
+          Global decrees that shape the world for every devotee.
+        </p>
+      </div>
+
+      <GlobalAIOracleCard />
+    </div>
+  );
+}

--- a/src/components/admin/global-ai-oracle-card.tsx
+++ b/src/components/admin/global-ai-oracle-card.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { authedFetch } from "@/lib/api-client";
+import { Button } from "@/components/ui/button";
+import { useToastStore } from "@/components/ui/toast";
+import { X } from "lucide-react";
+
+type SingleKeySection = { apiKey: string } | null;
+type OpenAISection = { apiKey: string; model: string; baseUrl: string } | null;
+type AzureSection = {
+  apiKey: string;
+  endpoint: string;
+  deployment: string;
+  apiVersion: string;
+} | null;
+
+interface GlobalAIConfigResponse {
+  claudeApi: SingleKeySection;
+  gemini: SingleKeySection;
+  groq: SingleKeySection;
+  openai: OpenAISection;
+  azureOpenai: AzureSection;
+  has: {
+    claudeApi: boolean;
+    gemini: boolean;
+    groq: boolean;
+    openai: boolean;
+    azureOpenai: boolean;
+  };
+  updatedAt: number | null;
+  updatedBy: string | null;
+}
+
+type ProviderKey = "claudeApi" | "gemini" | "groq" | "openai" | "azureOpenai";
+
+const PROVIDER_LABELS: Record<ProviderKey, string> = {
+  claudeApi: "Claude API",
+  gemini: "Google Gemini",
+  groq: "Groq",
+  openai: "OpenAI",
+  azureOpenai: "Azure OpenAI",
+};
+
+const MASKED = "••••••••";
+
+function isMasked(v: string) {
+  return v.includes(MASKED);
+}
+
+export function GlobalAIOracleCard() {
+  const addToast = useToastStore((s) => s.addToast);
+  const [data, setData] = useState<GlobalAIConfigResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [savingKey, setSavingKey] = useState<ProviderKey | null>(null);
+  const [removingKey, setRemovingKey] = useState<ProviderKey | null>(null);
+
+  const [claudeKey, setClaudeKey] = useState("");
+  const [geminiKey, setGeminiKey] = useState("");
+  const [groqKey, setGroqKey] = useState("");
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [openaiModel, setOpenaiModel] = useState("");
+  const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
+  const [azureKey, setAzureKey] = useState("");
+  const [azureEndpoint, setAzureEndpoint] = useState("");
+  const [azureDeployment, setAzureDeployment] = useState("");
+  const [azureApiVersion, setAzureApiVersion] = useState("");
+
+  useEffect(() => {
+    authedFetch("/api/admin/config/ai-provider")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((d: GlobalAIConfigResponse | null) => {
+        if (!d) return;
+        setData(d);
+        setOpenaiModel(d.openai?.model ?? "");
+        setOpenaiBaseUrl(d.openai?.baseUrl ?? "");
+        setAzureEndpoint(d.azureOpenai?.endpoint ?? "");
+        setAzureDeployment(d.azureOpenai?.deployment ?? "");
+        setAzureApiVersion(d.azureOpenai?.apiVersion ?? "2024-08-01-preview");
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const refresh = async () => {
+    const res = await authedFetch("/api/admin/config/ai-provider");
+    if (!res.ok) return;
+    const d = (await res.json()) as GlobalAIConfigResponse;
+    setData(d);
+    setClaudeKey("");
+    setGeminiKey("");
+    setGroqKey("");
+    setOpenaiKey("");
+    setAzureKey("");
+    setOpenaiModel(d.openai?.model ?? "");
+    setOpenaiBaseUrl(d.openai?.baseUrl ?? "");
+    setAzureEndpoint(d.azureOpenai?.endpoint ?? "");
+    setAzureDeployment(d.azureOpenai?.deployment ?? "");
+    setAzureApiVersion(d.azureOpenai?.apiVersion ?? "2024-08-01-preview");
+  };
+
+  const saveSection = async (provider: ProviderKey, payload: Record<string, unknown>) => {
+    setSavingKey(provider);
+    try {
+      const res = await authedFetch("/api/admin/config/ai-provider", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [provider]: payload }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      addToast(`Narayan Narayan! ${PROVIDER_LABELS[provider]} is inscribed for all devotees.`, "success");
+      await refresh();
+    } catch (err) {
+      console.error("[Narada Admin] GlobalAIOracle save:", err);
+      addToast(`Alas! ${PROVIDER_LABELS[provider]} could not be inscribed.`, "error");
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const removeSection = async (provider: ProviderKey) => {
+    setRemovingKey(provider);
+    try {
+      const res = await authedFetch("/api/admin/config/ai-provider", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ removeProviders: [provider] }),
+      });
+      if (!res.ok) throw new Error("Remove failed");
+      addToast(`Narayan Narayan! ${PROVIDER_LABELS[provider]} oracle has been forgotten.`, "success");
+      await refresh();
+    } catch (err) {
+      console.error("[Narada Admin] GlobalAIOracle remove:", err);
+      addToast(`Alas! ${PROVIDER_LABELS[provider]} could not be forgotten.`, "error");
+    } finally {
+      setRemovingKey(null);
+    }
+  };
+
+  const renderStatusRow = (provider: ProviderKey) => {
+    const has = data?.has?.[provider];
+    return (
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <h4 className="text-sm font-medium narada-text">{PROVIDER_LABELS[provider]}</h4>
+          <span
+            className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+              has
+                ? "bg-emerald-500/10 text-narada-emerald border border-emerald-500/30"
+                : "bg-white/[0.04] text-narada-text-secondary border border-white/[0.06]"
+            }`}
+          >
+            {has ? "Bestowed" : "Empty"}
+          </span>
+        </div>
+        {has && (
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => removeSection(provider)}
+            disabled={removingKey === provider}
+            className="text-narada-text-muted hover:text-narada-rose h-auto py-0 px-1"
+          >
+            <X className="w-3 h-3" />
+            Remove
+          </Button>
+        )}
+      </div>
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="glass-card p-5">
+        <h3 className="text-sm font-medium narada-text-secondary mb-4">Global AI Oracle</h3>
+        <p className="text-xs narada-text-secondary">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="glass-card p-5">
+      <h3 className="text-sm font-medium narada-text-secondary mb-1">Global AI Oracle</h3>
+      <p className="text-[11px] narada-text-secondary mb-4">
+        Bestow keys here so any devotee may channel the oracle without holding their own. Personal keys still take precedence unless a devotee opts in.
+      </p>
+
+      <div className="space-y-5">
+        {/* Claude API */}
+        <div className="border border-white/[0.06] rounded-xl p-3">
+          {renderStatusRow("claudeApi")}
+          <input
+            className="glass-input font-mono text-[13px]"
+            type="password"
+            placeholder={data?.claudeApi?.apiKey || "sk-ant-..."}
+            value={claudeKey}
+            onChange={(e) => setClaudeKey(e.target.value)}
+          />
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => saveSection("claudeApi", { apiKey: claudeKey })}
+              disabled={!claudeKey || isMasked(claudeKey) || savingKey === "claudeApi"}
+            >
+              {savingKey === "claudeApi" ? "Inscribing..." : "Inscribe"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Gemini */}
+        <div className="border border-white/[0.06] rounded-xl p-3">
+          {renderStatusRow("gemini")}
+          <input
+            className="glass-input font-mono text-[13px]"
+            type="password"
+            placeholder={data?.gemini?.apiKey || "AIza..."}
+            value={geminiKey}
+            onChange={(e) => setGeminiKey(e.target.value)}
+          />
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => saveSection("gemini", { apiKey: geminiKey })}
+              disabled={!geminiKey || isMasked(geminiKey) || savingKey === "gemini"}
+            >
+              {savingKey === "gemini" ? "Inscribing..." : "Inscribe"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Groq */}
+        <div className="border border-white/[0.06] rounded-xl p-3">
+          {renderStatusRow("groq")}
+          <input
+            className="glass-input font-mono text-[13px]"
+            type="password"
+            placeholder={data?.groq?.apiKey || "gsk_..."}
+            value={groqKey}
+            onChange={(e) => setGroqKey(e.target.value)}
+          />
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => saveSection("groq", { apiKey: groqKey })}
+              disabled={!groqKey || isMasked(groqKey) || savingKey === "groq"}
+            >
+              {savingKey === "groq" ? "Inscribing..." : "Inscribe"}
+            </Button>
+          </div>
+        </div>
+
+        {/* OpenAI */}
+        <div className="border border-white/[0.06] rounded-xl p-3">
+          {renderStatusRow("openai")}
+          <input
+            className="glass-input font-mono text-[13px] mb-2"
+            type="password"
+            placeholder={data?.openai?.apiKey || "sk-..."}
+            value={openaiKey}
+            onChange={(e) => setOpenaiKey(e.target.value)}
+          />
+          <div className="grid grid-cols-2 gap-2 mb-2">
+            <input
+              className="glass-input font-mono text-[13px]"
+              type="text"
+              placeholder="Model (e.g. gpt-4o)"
+              value={openaiModel}
+              onChange={(e) => setOpenaiModel(e.target.value)}
+            />
+            <input
+              className="glass-input font-mono text-[13px]"
+              type="text"
+              placeholder="Base URL (optional)"
+              value={openaiBaseUrl}
+              onChange={(e) => setOpenaiBaseUrl(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() =>
+                saveSection("openai", {
+                  apiKey: openaiKey,
+                  model: openaiModel,
+                  baseUrl: openaiBaseUrl,
+                })
+              }
+              disabled={
+                savingKey === "openai" ||
+                (!openaiKey && !data?.has?.openai) ||
+                (!!openaiKey && isMasked(openaiKey))
+              }
+            >
+              {savingKey === "openai" ? "Inscribing..." : "Inscribe"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Azure OpenAI */}
+        <div className="border border-white/[0.06] rounded-xl p-3">
+          {renderStatusRow("azureOpenai")}
+          <input
+            className="glass-input font-mono text-[13px] mb-2"
+            type="password"
+            placeholder={data?.azureOpenai?.apiKey || "your-azure-key"}
+            value={azureKey}
+            onChange={(e) => setAzureKey(e.target.value)}
+          />
+          <input
+            className="glass-input font-mono text-[13px] mb-2"
+            type="text"
+            placeholder="https://your-resource.openai.azure.com"
+            value={azureEndpoint}
+            onChange={(e) => setAzureEndpoint(e.target.value)}
+          />
+          <div className="grid grid-cols-2 gap-2 mb-2">
+            <input
+              className="glass-input font-mono text-[13px]"
+              type="text"
+              placeholder="Deployment (e.g. gpt-4o)"
+              value={azureDeployment}
+              onChange={(e) => setAzureDeployment(e.target.value)}
+            />
+            <input
+              className="glass-input font-mono text-[13px]"
+              type="text"
+              placeholder="2024-08-01-preview"
+              value={azureApiVersion}
+              onChange={(e) => setAzureApiVersion(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end mt-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() =>
+                saveSection("azureOpenai", {
+                  apiKey: azureKey,
+                  endpoint: azureEndpoint,
+                  deployment: azureDeployment,
+                  apiVersion: azureApiVersion,
+                })
+              }
+              disabled={
+                savingKey === "azureOpenai" ||
+                (!azureKey && !data?.has?.azureOpenai) ||
+                (!!azureKey && isMasked(azureKey)) ||
+                !azureEndpoint ||
+                !azureDeployment ||
+                !azureApiVersion
+              }
+            >
+              {savingKey === "azureOpenai" ? "Inscribing..." : "Inscribe"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {data?.updatedAt && (
+        <p className="text-[10px] narada-text-secondary mt-4">
+          Last inscribed: {new Date(data.updatedAt).toLocaleString()}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Calendar, Clock, Settings, Bug, LogOut, BarChart3 } from "lucide-react";
+import { Calendar, Clock, Settings, Bug, LogOut, BarChart3, ShieldCheck } from "lucide-react";
 import { useAuth } from "@/components/auth/auth-provider";
 import { authedFetch } from "@/lib/api-client";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
@@ -69,7 +69,11 @@ export function Sidebar() {
   }, []);
 
   const allNavItems = isAdmin
-    ? [...navItems, { href: "/admin/analytics", label: "Observatory", icon: BarChart3 }]
+    ? [
+        ...navItems,
+        { href: "/admin/analytics", label: "Observatory", icon: BarChart3 },
+        { href: "/admin/settings", label: "Sacred Sanctum", icon: ShieldCheck },
+      ]
     : navItems;
 
   return (

--- a/src/components/settings/ai-provider-card.tsx
+++ b/src/components/settings/ai-provider-card.tsx
@@ -5,8 +5,8 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { useToastStore } from "@/components/ui/toast";
 import { authedFetch } from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, RefreshCw, X } from "lucide-react";
-import type { AIProvider } from "@/types";
+import { ExternalLink, RefreshCw, X, Sparkles } from "lucide-react";
+import type { AIProvider, KeyProvider } from "@/types";
 
 const PROVIDERS: { value: AIProvider; label: string; description: string }[] = [
   {
@@ -34,26 +34,65 @@ const PROVIDERS: { value: AIProvider; label: string; description: string }[] = [
     label: "Groq",
     description: "Invokes the swift Groq oracle — blazing fast inference. Requires an API key.",
   },
+  {
+    value: "openai",
+    label: "OpenAI",
+    description: "Beseeches the OpenAI oracle (GPT). Requires an API key.",
+  },
+  {
+    value: "azure-openai",
+    label: "Azure OpenAI",
+    description: "Invokes OpenAI through your organization's Azure gateway. Requires endpoint, deployment, and key.",
+  },
 ];
 
-const API_KEY_CONFIGS: {
-  provider: AIProvider;
+type KeyConfig = {
+  provider: KeyProvider;
   field: string;
-  hasField: "hasGeminiKey" | "hasClaudeKey" | "hasGroqKey";
+  hasField: keyof KeySettingsSlice;
   label: string;
   displayName: string;
   placeholder: string;
   errorMsg: string;
   keyUrl: string;
-}[] = [
+};
+
+interface KeySettingsSlice {
+  hasGeminiKey: boolean;
+  hasClaudeKey: boolean;
+  hasGroqKey: boolean;
+  hasOpenaiKey: boolean;
+  hasAzureOpenaiKey: boolean;
+  hasAzureOpenaiEndpoint: boolean;
+  hasAzureOpenaiDeployment: boolean;
+}
+
+const API_KEY_CONFIGS: KeyConfig[] = [
   { provider: "gemini", field: "geminiApiKey", hasField: "hasGeminiKey", label: "Gemini API Key", displayName: "Gemini", placeholder: "AIza...", errorMsg: "The Gemini oracle requires an API key to speak", keyUrl: "https://aistudio.google.com/apikey" },
   { provider: "claude-api", field: "claudeApiKey", hasField: "hasClaudeKey", label: "Anthropic API Key", displayName: "Claude", placeholder: "sk-ant-...", errorMsg: "The Claude gateway requires an API key to open", keyUrl: "https://console.anthropic.com/settings/keys" },
   { provider: "groq", field: "groqApiKey", hasField: "hasGroqKey", label: "Groq API Key", displayName: "Groq", placeholder: "gsk_...", errorMsg: "The Groq oracle requires an API key to awaken", keyUrl: "https://console.groq.com/keys" },
+  { provider: "openai", field: "openaiApiKey", hasField: "hasOpenaiKey", label: "OpenAI API Key", displayName: "OpenAI", placeholder: "sk-...", errorMsg: "The OpenAI oracle requires an API key to whisper back", keyUrl: "https://platform.openai.com/api-keys" },
+  { provider: "azure-openai", field: "azureOpenaiApiKey", hasField: "hasAzureOpenaiKey", label: "Azure OpenAI API Key", displayName: "Azure OpenAI", placeholder: "your-azure-key", errorMsg: "The Azure scrolls demand a key, endpoint, and deployment", keyUrl: "https://portal.azure.com/" },
 ];
 
+const GLOBAL_STATUS_KEY: Record<KeyProvider, string> = {
+  "claude-api": "claudeApi",
+  gemini: "gemini",
+  groq: "groq",
+  openai: "openai",
+  "azure-openai": "azureOpenai",
+};
+
 export function AIProviderCard() {
-  const { aiSettings, aiLoading, aiError, fetchAIProviderSettings, saveAIProviderSettings } =
-    useSettingsStore();
+  const {
+    aiSettings,
+    aiLoading,
+    aiError,
+    fetchAIProviderSettings,
+    saveAIProviderSettings,
+    globalAIStatus,
+    fetchGlobalAIStatus,
+  } = useSettingsStore();
   const addToast = useToastStore((s) => s.addToast);
 
   const [selected, setSelected] = useState<AIProvider>(aiSettings.aiProvider);
@@ -61,7 +100,13 @@ export function AIProviderCard() {
     geminiApiKey: aiSettings.geminiApiKey,
     claudeApiKey: aiSettings.claudeApiKey,
     groqApiKey: aiSettings.groqApiKey,
+    openaiApiKey: aiSettings.openaiApiKey,
+    azureOpenaiApiKey: aiSettings.azureOpenaiApiKey,
   });
+  const [azureEndpoint, setAzureEndpoint] = useState(aiSettings.azureOpenaiEndpoint);
+  const [azureDeployment, setAzureDeployment] = useState(aiSettings.azureOpenaiDeployment);
+  const [azureApiVersion, setAzureApiVersion] = useState(aiSettings.azureOpenaiApiVersion);
+  const [useGlobalFor, setUseGlobalFor] = useState<Partial<Record<KeyProvider, boolean>>>(aiSettings.useGlobalFor);
   const [deepgramKey, setDeepgramKey] = useState(aiSettings.deepgramApiKey);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
@@ -92,7 +137,8 @@ export function AIProviderCard() {
 
   useEffect(() => {
     fetchAIProviderSettings();
-  }, [fetchAIProviderSettings]);
+    fetchGlobalAIStatus();
+  }, [fetchAIProviderSettings, fetchGlobalAIStatus]);
 
   useEffect(() => {
     setSelected(aiSettings.aiProvider);
@@ -100,7 +146,13 @@ export function AIProviderCard() {
       geminiApiKey: aiSettings.geminiApiKey,
       claudeApiKey: aiSettings.claudeApiKey,
       groqApiKey: aiSettings.groqApiKey,
+      openaiApiKey: aiSettings.openaiApiKey,
+      azureOpenaiApiKey: aiSettings.azureOpenaiApiKey,
     });
+    setAzureEndpoint(aiSettings.azureOpenaiEndpoint);
+    setAzureDeployment(aiSettings.azureOpenaiDeployment);
+    setAzureApiVersion(aiSettings.azureOpenaiApiVersion);
+    setUseGlobalFor(aiSettings.useGlobalFor);
     setDeepgramKey(aiSettings.deepgramApiKey);
   }, [aiSettings]);
 
@@ -108,28 +160,62 @@ export function AIProviderCard() {
 
   const getActiveKeyConfig = () => API_KEY_CONFIGS.find((c) => c.provider === selected);
 
+  const isUsingGlobal = (provider: KeyProvider) => useGlobalFor[provider] === true;
+  const globalAvailable = (provider: KeyProvider) =>
+    !!globalAIStatus[GLOBAL_STATUS_KEY[provider]];
+
+  const handleToggleGlobal = (provider: KeyProvider, next: boolean) => {
+    setUseGlobalFor((prev) => ({ ...prev, [provider]: next }));
+    setKeyError(false);
+  };
+
   const handleTest = async () => {
     setKeyError(false);
     setTestResult(null);
 
     const config = getActiveKeyConfig();
-    if (config && !apiKeys[config.field]?.trim() && !aiSettings[config.hasField]) {
-      setKeyError(true);
-      setTestResult({ type: "error", message: config.errorMsg });
-      return;
-    }
 
     setTesting(true);
     try {
-      const isMasked = (v: string) => v.includes("••••••••");
       const payload: Record<string, unknown> = { provider: selected };
 
       if (config) {
-        const keyValue = apiKeys[config.field];
-        if (keyValue && !isMasked(keyValue)) {
-          payload[config.field] = keyValue;
+        const usingGlobal = isUsingGlobal(config.provider);
+        if (usingGlobal) {
+          if (!globalAvailable(config.provider)) {
+            setTestResult({ type: "error", message: "Alas! No global oracle has been bestowed by the high priest yet." });
+            setTesting(false);
+            return;
+          }
+          payload.useGlobal = true;
         } else {
-          payload.useStoredKey = true;
+          const keyValue = apiKeys[config.field];
+          const isMasked = (v: string) => v.includes("••••••••");
+          if (config.provider === "azure-openai") {
+            if (!keyValue && !aiSettings.hasAzureOpenaiKey) {
+              setKeyError(true);
+              setTestResult({ type: "error", message: config.errorMsg });
+              setTesting(false);
+              return;
+            }
+            if (keyValue && !isMasked(keyValue)) payload.azureOpenaiApiKey = keyValue;
+            payload.azureOpenaiEndpoint = azureEndpoint;
+            payload.azureOpenaiDeployment = azureDeployment;
+            payload.azureOpenaiApiVersion = azureApiVersion;
+            if (!keyValue) payload.useStoredKey = true;
+          } else {
+            if (!keyValue?.trim() && !aiSettings[config.hasField]) {
+              setKeyError(true);
+              setTestResult({ type: "error", message: config.errorMsg });
+              setTesting(false);
+              return;
+            }
+            if (keyValue && !isMasked(keyValue)) {
+              payload[config.field] = keyValue;
+            } else {
+              payload.useStoredKey = true;
+            }
+          }
         }
       }
 
@@ -157,21 +243,42 @@ export function AIProviderCard() {
     setKeyError(false);
 
     const config = getActiveKeyConfig();
-    if (config && !apiKeys[config.field]?.trim() && !aiSettings[config.hasField]) {
-      setKeyError(true);
-      addToast(config.errorMsg, "error");
-      return;
+    if (config && !isUsingGlobal(config.provider)) {
+      const keyValue = apiKeys[config.field];
+      if (config.provider === "azure-openai") {
+        const hasStoredAzure = aiSettings.hasAzureOpenaiKey && aiSettings.hasAzureOpenaiEndpoint && aiSettings.hasAzureOpenaiDeployment;
+        const incoming = keyValue?.trim() && azureEndpoint?.trim() && azureDeployment?.trim();
+        if (!hasStoredAzure && !incoming) {
+          setKeyError(true);
+          addToast(config.errorMsg, "error");
+          return;
+        }
+      } else {
+        if (!keyValue?.trim() && !aiSettings[config.hasField]) {
+          setKeyError(true);
+          addToast(config.errorMsg, "error");
+          return;
+        }
+      }
     }
 
     setSaving(true);
     try {
-      const saveData: Record<string, unknown> = { aiProvider: selected };
+      const saveData: Record<string, unknown> = {
+        aiProvider: selected,
+        useGlobalFor,
+      };
       if (config) {
         saveData[config.field] = apiKeys[config.field] || undefined;
+        if (config.provider === "azure-openai") {
+          saveData.azureOpenaiEndpoint = azureEndpoint || undefined;
+          saveData.azureOpenaiDeployment = azureDeployment || undefined;
+          saveData.azureOpenaiApiVersion = azureApiVersion || undefined;
+        }
       }
       saveData.deepgramApiKey = deepgramKey || undefined;
 
-      await saveAIProviderSettings(saveData as Parameters<typeof saveAIProviderSettings>[0]);
+      await saveAIProviderSettings(saveData as unknown as Parameters<typeof saveAIProviderSettings>[0]);
       addToast("Narayan Narayan! Your oracle of choice is set", "success");
     } catch (err) {
       console.error("[Narada] AIProviderCard handleSave:", err);
@@ -209,6 +316,9 @@ export function AIProviderCard() {
   }
 
   const activeKeyConfig = getActiveKeyConfig();
+  const activeGlobalAvailable = activeKeyConfig ? globalAvailable(activeKeyConfig.provider) : false;
+  const activeUsingGlobal = activeKeyConfig ? isUsingGlobal(activeKeyConfig.provider) : false;
+  const isAzure = activeKeyConfig?.provider === "azure-openai";
 
   return (
     <div className="glass-card p-6">
@@ -240,8 +350,10 @@ export function AIProviderCard() {
               onChange={() => setSelected(p.value)}
               className="mt-1 accent-narada-primary"
             />
-            <div>
-              <div className="text-sm font-medium text-narada-text">{p.label}</div>
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <div className="text-sm font-medium text-narada-text">{p.label}</div>
+              </div>
               <div className="text-xs text-narada-text-secondary mt-0.5">
                 {p.description}
               </div>
@@ -251,42 +363,114 @@ export function AIProviderCard() {
       </div>
 
       {activeKeyConfig && (
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-2">
-            <label className="block text-xs font-semibold text-narada-text-secondary uppercase tracking-wider">
-              {activeKeyConfig.label}
-            </label>
-            <a
-              href={activeKeyConfig.keyUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-narada-primary hover:text-narada-primary/80 transition-colors"
-            >
-              Get API Key
-              <ExternalLink className="w-3 h-3" />
-            </a>
-          </div>
-          <input
-            className={`glass-input font-mono text-[13px] ${keyError ? "!border-narada-rose" : ""}`}
-            type="password"
-            placeholder={activeKeyConfig.placeholder}
-            value={apiKeys[activeKeyConfig.field] ?? ""}
-            onChange={(e) => { setApiKeys((prev) => ({ ...prev, [activeKeyConfig.field]: e.target.value })); setKeyError(false); }}
-          />
-          {aiSettings[activeKeyConfig.hasField] && (
-            <div className="flex items-center gap-2 mt-1.5">
-              <p className="text-xs text-narada-emerald">Key configured</p>
-              <Button
-                variant="ghost"
-                size="xs"
-                onClick={() => handleRemoveKey(activeKeyConfig.field, activeKeyConfig.displayName)}
-                disabled={removingKey === activeKeyConfig.field}
-                className="text-narada-text-muted hover:text-narada-rose h-auto py-0 px-1"
-              >
-                <X className="w-3 h-3" />
-                Remove
-              </Button>
+        <div className="mb-4 space-y-3">
+          <div className="flex items-start justify-between gap-3 p-3 rounded-xl bg-narada-violet/[0.05] border border-narada-violet/20">
+            <div className="flex items-start gap-2.5">
+              <Sparkles className="w-4 h-4 text-narada-violet mt-0.5 shrink-0" />
+              <div>
+                <div className="text-sm font-medium text-narada-text">Use the global oracle</div>
+                <div className="text-xs text-narada-text-secondary mt-0.5">
+                  {activeGlobalAvailable
+                    ? "Your high priest has set a global oracle for this provider."
+                    : "Awaiting bestowal — no global oracle set yet by the high priest."}
+                </div>
+              </div>
             </div>
+            <label className="relative inline-flex items-center cursor-pointer mt-0.5 shrink-0">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={activeUsingGlobal}
+                onChange={(e) => handleToggleGlobal(activeKeyConfig.provider, e.target.checked)}
+              />
+              <div className="w-9 h-5 bg-white/[0.08] rounded-full peer peer-checked:bg-narada-violet/60 transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-transform peer-checked:after:translate-x-4" />
+            </label>
+          </div>
+
+          {!activeUsingGlobal && (
+            <>
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="block text-xs font-semibold text-narada-text-secondary uppercase tracking-wider">
+                    {activeKeyConfig.label}
+                  </label>
+                  <a
+                    href={activeKeyConfig.keyUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-narada-primary hover:text-narada-primary/80 transition-colors"
+                  >
+                    Get API Key
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </div>
+                <input
+                  className={`glass-input font-mono text-[13px] ${keyError ? "!border-narada-rose" : ""}`}
+                  type="password"
+                  placeholder={activeKeyConfig.placeholder}
+                  value={apiKeys[activeKeyConfig.field] ?? ""}
+                  onChange={(e) => { setApiKeys((prev) => ({ ...prev, [activeKeyConfig.field]: e.target.value })); setKeyError(false); }}
+                />
+                {aiSettings[activeKeyConfig.hasField] && (
+                  <div className="flex items-center gap-2 mt-1.5">
+                    <p className="text-xs text-narada-emerald">Key configured</p>
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => handleRemoveKey(activeKeyConfig.field, activeKeyConfig.displayName)}
+                      disabled={removingKey === activeKeyConfig.field}
+                      className="text-narada-text-muted hover:text-narada-rose h-auto py-0 px-1"
+                    >
+                      <X className="w-3 h-3" />
+                      Remove
+                    </Button>
+                  </div>
+                )}
+              </div>
+
+              {isAzure && (
+                <div className="grid grid-cols-1 gap-3">
+                  <div>
+                    <label className="block text-xs font-semibold text-narada-text-secondary uppercase tracking-wider mb-2">
+                      Azure Endpoint
+                    </label>
+                    <input
+                      className="glass-input font-mono text-[13px]"
+                      type="text"
+                      placeholder="https://your-resource.openai.azure.com"
+                      value={azureEndpoint}
+                      onChange={(e) => setAzureEndpoint(e.target.value)}
+                    />
+                  </div>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs font-semibold text-narada-text-secondary uppercase tracking-wider mb-2">
+                        Deployment
+                      </label>
+                      <input
+                        className="glass-input font-mono text-[13px]"
+                        type="text"
+                        placeholder="gpt-4o"
+                        value={azureDeployment}
+                        onChange={(e) => setAzureDeployment(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-semibold text-narada-text-secondary uppercase tracking-wider mb-2">
+                        API Version
+                      </label>
+                      <input
+                        className="glass-input font-mono text-[13px]"
+                        type="text"
+                        placeholder="2024-08-01-preview"
+                        value={azureApiVersion}
+                        onChange={(e) => setAzureApiVersion(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
       )}

--- a/src/components/update/step-processing.tsx
+++ b/src/components/update/step-processing.tsx
@@ -13,6 +13,9 @@ const PROVIDER_LABELS: Record<string, string> = {
   "local-cursor": "Local Cursor CLI",
   "gemini": "Gemini AI",
   "claude-api": "Claude API",
+  "groq": "Groq",
+  "openai": "OpenAI",
+  "azure-openai": "Azure OpenAI",
 };
 
 const STAGE_LABELS: Record<ProcessingStage, string> = {

--- a/src/lib/ai/enrich-issue.ts
+++ b/src/lib/ai/enrich-issue.ts
@@ -1,16 +1,26 @@
 import { spawn } from "child_process";
-import type { AIProvider } from "@/types";
+import type { AIProvider, KeyProvider } from "@/types";
 import { buildIssueSystemPrompt, buildIssueUserMessage } from "./issue-prompt";
+import { resolveProviderConfig, type AppSettings } from "./index";
+import { getGlobalAIConfig } from "@/lib/global-ai-config";
+import { DEFAULT_OPENAI_MODEL } from "./openai-provider";
+import { GROQ_MODEL } from "./groq-provider";
 
 export interface EnrichedIssue {
   title: string;
   body: string;
 }
 
-interface AppSettings {
-  aiProvider?: string;
-  claudeApiKey?: string | null;
-  geminiApiKey?: string | null;
+const KEY_PROVIDER_SET = new Set<AIProvider>([
+  "claude-api",
+  "gemini",
+  "groq",
+  "openai",
+  "azure-openai",
+]);
+
+function isKeyProvider(p: AIProvider): p is KeyProvider {
+  return KEY_PROVIDER_SET.has(p);
 }
 
 export async function enrichIssueDescription(
@@ -27,64 +37,109 @@ export async function enrichIssueDescription(
   let rawOutput: string;
 
   try {
-    switch (provider) {
-      case "claude-api": {
-        const apiKey = settings?.claudeApiKey;
-        if (!apiKey) throw new Error("Anthropic API key not configured");
-        const Anthropic = (await import("@anthropic-ai/sdk")).default;
-        const client = new Anthropic({ apiKey });
-        const response = await client.messages.create({
-          model: "claude-sonnet-4-5-20250514",
-          max_tokens: 2048,
-          system: systemPrompt,
-          messages: [{ role: "user", content: userMessage }],
-        });
-        const textBlock = response.content.find((b) => b.type === "text");
-        if (!textBlock || textBlock.type !== "text") {
-          throw new Error("No text response from Claude API");
+    if (provider === "local-claude") {
+      rawOutput = await spawnCli("claude", [
+        "--print", "--no-session-persistence", "--model", "sonnet",
+        "--tools", "", "--append-system-prompt", systemPrompt,
+        "--max-budget-usd", "0.50",
+      ], userMessage);
+    } else if (provider === "local-cursor") {
+      const combined = `${systemPrompt}\n\n${userMessage}`;
+      rawOutput = await spawnCli("agent", ["--trust", "-p", combined]);
+    } else if (isKeyProvider(provider)) {
+      const global = await getGlobalAIConfig();
+      const resolved = resolveProviderConfig(provider, settings ?? null, global);
+
+      switch (resolved.kind) {
+        case "claude-api": {
+          const Anthropic = (await import("@anthropic-ai/sdk")).default;
+          const client = new Anthropic({ apiKey: resolved.apiKey });
+          const response = await client.messages.create({
+            model: "claude-sonnet-4-5-20250514",
+            max_tokens: 2048,
+            system: systemPrompt,
+            messages: [{ role: "user", content: userMessage }],
+          });
+          const textBlock = response.content.find((b) => b.type === "text");
+          if (!textBlock || textBlock.type !== "text") {
+            throw new Error("No text response from Claude API");
+          }
+          rawOutput = textBlock.text;
+          break;
         }
-        rawOutput = textBlock.text;
-        break;
+        case "gemini": {
+          const { GoogleGenerativeAI } = await import("@google/generative-ai");
+          const genAI = new GoogleGenerativeAI(resolved.apiKey);
+          const model = genAI.getGenerativeModel({
+            model: "gemini-2.0-flash",
+            systemInstruction: systemPrompt,
+          });
+          const result = await model.generateContent(userMessage);
+          rawOutput = result.response.text();
+          break;
+        }
+        case "groq": {
+          const { default: Groq } = await import("groq-sdk");
+          const client = new Groq({ apiKey: resolved.apiKey, timeout: 60_000 });
+          const response = await client.chat.completions.create({
+            model: GROQ_MODEL,
+            max_tokens: 2048,
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: userMessage },
+            ],
+          });
+          rawOutput = response.choices[0]?.message?.content ?? "";
+          break;
+        }
+        case "openai": {
+          const { default: OpenAI } = await import("openai");
+          const client = new OpenAI({
+            apiKey: resolved.apiKey,
+            baseURL: resolved.baseUrl || undefined,
+            timeout: 60_000,
+          });
+          const response = await client.chat.completions.create({
+            model: resolved.model || DEFAULT_OPENAI_MODEL,
+            max_completion_tokens: 2048,
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: userMessage },
+            ],
+          });
+          rawOutput = response.choices[0]?.message?.content ?? "";
+          break;
+        }
+        case "azure-openai": {
+          const { AzureOpenAI } = await import("openai");
+          const client = new AzureOpenAI({
+            apiKey: resolved.apiKey,
+            endpoint: resolved.endpoint,
+            deployment: resolved.deployment,
+            apiVersion: resolved.apiVersion,
+            timeout: 60_000,
+          });
+          const response = await client.chat.completions.create({
+            model: resolved.deployment,
+            max_completion_tokens: 2048,
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: userMessage },
+            ],
+          });
+          rawOutput = response.choices[0]?.message?.content ?? "";
+          break;
+        }
       }
-
-      case "gemini": {
-        const apiKey = settings?.geminiApiKey;
-        if (!apiKey) throw new Error("Gemini API key not configured");
-        const { GoogleGenerativeAI } = await import("@google/generative-ai");
-        const genAI = new GoogleGenerativeAI(apiKey);
-        const model = genAI.getGenerativeModel({
-          model: "gemini-2.0-flash",
-          systemInstruction: systemPrompt,
-        });
-        const result = await model.generateContent(userMessage);
-        rawOutput = result.response.text();
-        break;
-      }
-
-      case "local-claude": {
-        rawOutput = await spawnCli("claude", [
-          "--print", "--no-session-persistence", "--model", "sonnet",
-          "--tools", "", "--append-system-prompt", systemPrompt,
-          "--max-budget-usd", "0.50",
-        ], userMessage);
-        break;
-      }
-
-      case "local-cursor": {
-        const combined = `${systemPrompt}\n\n${userMessage}`;
-        rawOutput = await spawnCli("agent", ["--trust", "-p", combined]);
-        break;
-      }
-
-      default:
-        throw new Error(`Unknown AI provider: ${provider}`);
+    } else {
+      throw new Error(`Unknown AI provider: ${provider}`);
     }
   } catch (err) {
     console.error("[Narada → Issue Enrichment] AI enrichment failed, using raw description:", err);
     return { title, body: description.trim() || "No description provided." };
   }
 
-  return parseEnrichedOutput(rawOutput, title);
+  return parseEnrichedOutput(rawOutput!, title);
 }
 
 function parseEnrichedOutput(raw: string, fallbackTitle: string): EnrichedIssue {

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -1,11 +1,159 @@
 import type { AIParseProvider } from "./types";
-import type { AIProvider } from "@/types";
+import type { AIProvider, KeyProvider } from "@/types";
+import { getGlobalAIConfig, type GlobalAIProviderConfig } from "@/lib/global-ai-config";
+import { DEFAULT_AZURE_API_VERSION } from "./openai-provider";
 
-interface AppSettings {
+export interface UseGlobalFor {
+  "claude-api"?: boolean;
+  gemini?: boolean;
+  groq?: boolean;
+  openai?: boolean;
+  "azure-openai"?: boolean;
+}
+
+export interface AppSettings {
   aiProvider?: string;
   geminiApiKey?: string | null;
   claudeApiKey?: string | null;
   groqApiKey?: string | null;
+  openaiApiKey?: string | null;
+  azureOpenaiApiKey?: string | null;
+  azureOpenaiEndpoint?: string | null;
+  azureOpenaiDeployment?: string | null;
+  azureOpenaiApiVersion?: string | null;
+  useGlobalFor?: UseGlobalFor;
+}
+
+interface ClaudeResolved { kind: "claude-api"; apiKey: string }
+interface GeminiResolved { kind: "gemini"; apiKey: string }
+interface GroqResolved { kind: "groq"; apiKey: string }
+interface OpenAIResolved {
+  kind: "openai";
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}
+interface AzureResolved {
+  kind: "azure-openai";
+  apiKey: string;
+  endpoint: string;
+  deployment: string;
+  apiVersion: string;
+}
+
+export type ResolvedProviderConfig =
+  | ClaudeResolved
+  | GeminiResolved
+  | GroqResolved
+  | OpenAIResolved
+  | AzureResolved;
+
+function wantsGlobal(provider: KeyProvider, settings: AppSettings | null | undefined): boolean {
+  return settings?.useGlobalFor?.[provider] === true;
+}
+
+function personalAzureComplete(s: AppSettings | null | undefined): boolean {
+  return !!(s?.azureOpenaiApiKey && s.azureOpenaiEndpoint && s.azureOpenaiDeployment);
+}
+
+export function resolveProviderConfig(
+  provider: KeyProvider,
+  settings: AppSettings | null | undefined,
+  global: GlobalAIProviderConfig
+): ResolvedProviderConfig {
+  const preferGlobal = wantsGlobal(provider, settings);
+
+  const fromGlobal = (): ResolvedProviderConfig | null => {
+    switch (provider) {
+      case "claude-api":
+        return global.claudeApi?.apiKey
+          ? { kind: "claude-api", apiKey: global.claudeApi.apiKey }
+          : null;
+      case "gemini":
+        return global.gemini?.apiKey
+          ? { kind: "gemini", apiKey: global.gemini.apiKey }
+          : null;
+      case "groq":
+        return global.groq?.apiKey
+          ? { kind: "groq", apiKey: global.groq.apiKey }
+          : null;
+      case "openai":
+        return global.openai?.apiKey
+          ? {
+              kind: "openai",
+              apiKey: global.openai.apiKey,
+              model: global.openai.model,
+              baseUrl: global.openai.baseUrl,
+            }
+          : null;
+      case "azure-openai": {
+        const a = global.azureOpenai;
+        if (a?.apiKey && a.endpoint && a.deployment) {
+          return {
+            kind: "azure-openai",
+            apiKey: a.apiKey,
+            endpoint: a.endpoint,
+            deployment: a.deployment,
+            apiVersion: a.apiVersion || DEFAULT_AZURE_API_VERSION,
+          };
+        }
+        return null;
+      }
+    }
+  };
+
+  const fromPersonal = (): ResolvedProviderConfig | null => {
+    switch (provider) {
+      case "claude-api":
+        return settings?.claudeApiKey
+          ? { kind: "claude-api", apiKey: settings.claudeApiKey }
+          : null;
+      case "gemini":
+        return settings?.geminiApiKey
+          ? { kind: "gemini", apiKey: settings.geminiApiKey }
+          : null;
+      case "groq":
+        return settings?.groqApiKey
+          ? { kind: "groq", apiKey: settings.groqApiKey }
+          : null;
+      case "openai":
+        return settings?.openaiApiKey
+          ? { kind: "openai", apiKey: settings.openaiApiKey }
+          : null;
+      case "azure-openai":
+        return personalAzureComplete(settings)
+          ? {
+              kind: "azure-openai",
+              apiKey: settings!.azureOpenaiApiKey!,
+              endpoint: settings!.azureOpenaiEndpoint!,
+              deployment: settings!.azureOpenaiDeployment!,
+              apiVersion: settings!.azureOpenaiApiVersion || DEFAULT_AZURE_API_VERSION,
+            }
+          : null;
+    }
+  };
+
+  const first = preferGlobal ? fromGlobal() : fromPersonal();
+  if (first) return first;
+  const second = preferGlobal ? fromPersonal() : fromGlobal();
+  if (second) return second;
+
+  throw new Error(missingConfigMessage(provider));
+}
+
+function missingConfigMessage(provider: KeyProvider): string {
+  switch (provider) {
+    case "claude-api":
+      return "Alas! The Claude gateway lies dormant — grant its key in Sacred Configurations or ask your high priest to set the global oracle.";
+    case "gemini":
+      return "Alas! The Gemini oracle awaits its mantra — grant its key in Sacred Configurations or ask your high priest to set the global oracle.";
+    case "groq":
+      return "Alas! The Groq oracle slumbers — grant its key in Sacred Configurations or ask your high priest to set the global oracle.";
+    case "openai":
+      return "Alas! The OpenAI oracle awaits — grant its key in Sacred Configurations or ask your high priest to set the global oracle.";
+    case "azure-openai":
+      return "Alas! The Azure OpenAI scrolls are incomplete — grant its endpoint, deployment, and key in Sacred Configurations or ask your high priest to set the global oracle.";
+  }
 }
 
 export async function getAIProvider(settings?: AppSettings | null): Promise<AIParseProvider> {
@@ -14,24 +162,6 @@ export async function getAIProvider(settings?: AppSettings | null): Promise<AIPa
   console.log(`[AI] Using provider: ${provider}`);
 
   switch (provider) {
-    case "gemini": {
-      const apiKey = settings?.geminiApiKey;
-      if (!apiKey) {
-        throw new Error("Gemini API key not configured. Add it in Settings.");
-      }
-      const { GeminiProvider } = await import("./gemini-provider");
-      return new GeminiProvider(apiKey);
-    }
-
-    case "claude-api": {
-      const apiKey = settings?.claudeApiKey;
-      if (!apiKey) {
-        throw new Error("Anthropic API key not configured. Add it in Settings.");
-      }
-      const { ClaudeAPIProvider } = await import("./claude-api-provider");
-      return new ClaudeAPIProvider(apiKey);
-    }
-
     case "local-claude": {
       const { LocalClaudeProvider } = await import("./local-claude-provider");
       return new LocalClaudeProvider();
@@ -42,13 +172,41 @@ export async function getAIProvider(settings?: AppSettings | null): Promise<AIPa
       return new LocalCursorProvider();
     }
 
-    case "groq": {
-      const apiKey = settings?.groqApiKey;
-      if (!apiKey) {
-        throw new Error("Groq API key not configured. Add it in Settings.");
+    case "gemini":
+    case "claude-api":
+    case "groq":
+    case "openai":
+    case "azure-openai": {
+      const global = await getGlobalAIConfig();
+      const resolved = resolveProviderConfig(provider, settings ?? null, global);
+
+      if (resolved.kind === "gemini") {
+        const { GeminiProvider } = await import("./gemini-provider");
+        return new GeminiProvider(resolved.apiKey);
       }
-      const { GroqProvider } = await import("./groq-provider");
-      return new GroqProvider(apiKey);
+      if (resolved.kind === "claude-api") {
+        const { ClaudeAPIProvider } = await import("./claude-api-provider");
+        return new ClaudeAPIProvider(resolved.apiKey);
+      }
+      if (resolved.kind === "groq") {
+        const { GroqProvider } = await import("./groq-provider");
+        return new GroqProvider(resolved.apiKey);
+      }
+      if (resolved.kind === "openai") {
+        const { OpenAIProvider } = await import("./openai-provider");
+        return new OpenAIProvider({
+          apiKey: resolved.apiKey,
+          model: resolved.model,
+          baseUrl: resolved.baseUrl,
+        });
+      }
+      const { AzureOpenAIProvider } = await import("./openai-provider");
+      return new AzureOpenAIProvider({
+        apiKey: resolved.apiKey,
+        endpoint: resolved.endpoint,
+        deployment: resolved.deployment,
+        apiVersion: resolved.apiVersion,
+      });
     }
 
     default:

--- a/src/lib/ai/openai-provider.ts
+++ b/src/lib/ai/openai-provider.ts
@@ -1,0 +1,120 @@
+import OpenAI, { AzureOpenAI } from "openai";
+import type { ClaudeParseResult } from "@/types/claude";
+import type { AIParseProvider, RepeatEntryInput } from "./types";
+import { buildSystemPrompt, buildUserMessage, PARSE_RESULT_JSON_SCHEMA } from "./prompt";
+
+export const DEFAULT_OPENAI_MODEL = "gpt-4o";
+export const DEFAULT_AZURE_API_VERSION = "2024-08-01-preview";
+
+const JSON_INSTRUCTION = `\n\nRespond with ONLY a valid JSON object matching this schema:\n${JSON.stringify(PARSE_RESULT_JSON_SCHEMA, null, 2)}`;
+
+function parseJsonOrThrow(content: string | null | undefined, label: string): ClaudeParseResult {
+  if (!content) {
+    throw new Error(`${label} returned an empty response`);
+  }
+  try {
+    return JSON.parse(content) as ClaudeParseResult;
+  } catch (parseErr) {
+    console.error(`[Narada → ${label}] JSON parse failed:`, parseErr, "Raw text:", content.slice(0, 500));
+    throw new Error(`${label} returned invalid JSON`);
+  }
+}
+
+export class OpenAIProvider implements AIParseProvider {
+  name: string;
+  private client: OpenAI;
+  private model: string;
+
+  constructor(opts: { apiKey: string; model?: string; baseUrl?: string }) {
+    this.client = new OpenAI({
+      apiKey: opts.apiKey,
+      baseURL: opts.baseUrl || undefined,
+      timeout: 60_000,
+    });
+    this.model = opts.model || DEFAULT_OPENAI_MODEL;
+    this.name = `OpenAI (${this.model})`;
+  }
+
+  async parseTranscript(
+    transcript: string,
+    date: string,
+    repeatEntries: RepeatEntryInput[]
+  ): Promise<ClaudeParseResult> {
+    const systemPrompt = buildSystemPrompt(date, repeatEntries) + JSON_INSTRUCTION;
+    const userMessage = buildUserMessage(transcript);
+
+    console.log(`[Narada → OpenAI] Sending request — model=${this.model}, system_prompt=${systemPrompt.length} chars, user_message=${userMessage.length} chars`);
+
+    let response;
+    try {
+      response = await this.client.chat.completions.create({
+        model: this.model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userMessage },
+        ],
+        response_format: { type: "json_object" },
+        max_completion_tokens: 4096,
+      });
+    } catch (err) {
+      console.error("[Narada → OpenAI] API call failed:", err);
+      throw err;
+    }
+
+    const content = response.choices[0]?.message?.content;
+    return parseJsonOrThrow(content, "OpenAI");
+  }
+}
+
+export class AzureOpenAIProvider implements AIParseProvider {
+  name: string;
+  private client: AzureOpenAI;
+  private deployment: string;
+
+  constructor(opts: {
+    apiKey: string;
+    endpoint: string;
+    deployment: string;
+    apiVersion: string;
+  }) {
+    this.client = new AzureOpenAI({
+      apiKey: opts.apiKey,
+      endpoint: opts.endpoint,
+      deployment: opts.deployment,
+      apiVersion: opts.apiVersion,
+      timeout: 60_000,
+    });
+    this.deployment = opts.deployment;
+    this.name = `Azure OpenAI (${opts.deployment})`;
+  }
+
+  async parseTranscript(
+    transcript: string,
+    date: string,
+    repeatEntries: RepeatEntryInput[]
+  ): Promise<ClaudeParseResult> {
+    const systemPrompt = buildSystemPrompt(date, repeatEntries) + JSON_INSTRUCTION;
+    const userMessage = buildUserMessage(transcript);
+
+    console.log(`[Narada → Azure OpenAI] Sending request — deployment=${this.deployment}, system_prompt=${systemPrompt.length} chars, user_message=${userMessage.length} chars`);
+
+    let response;
+    try {
+      response = await this.client.chat.completions.create({
+        model: this.deployment,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userMessage },
+        ],
+        response_format: { type: "json_object" },
+        max_completion_tokens: 4096,
+      });
+    } catch (err) {
+      console.error("[Narada → Azure OpenAI] API call failed:", err);
+      throw err;
+    }
+
+    const content = response.choices[0]?.message?.content;
+    return parseJsonOrThrow(content, "Azure OpenAI");
+  }
+}

--- a/src/lib/global-ai-config.ts
+++ b/src/lib/global-ai-config.ts
@@ -1,0 +1,130 @@
+import { adminDb } from "./firebase-admin";
+import type { KeyProvider } from "@/types";
+
+export interface OpenAIGlobalConfig {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}
+
+export interface AzureOpenAIGlobalConfig {
+  apiKey: string;
+  endpoint: string;
+  deployment: string;
+  apiVersion: string;
+}
+
+export interface SingleKeyGlobalConfig {
+  apiKey: string;
+}
+
+export interface GlobalAIProviderConfig {
+  claudeApi?: SingleKeyGlobalConfig;
+  gemini?: SingleKeyGlobalConfig;
+  groq?: SingleKeyGlobalConfig;
+  openai?: OpenAIGlobalConfig;
+  azureOpenai?: AzureOpenAIGlobalConfig;
+  updatedAt?: number;
+  updatedBy?: string;
+}
+
+const DOC_PATH = { collection: "config", id: "aiProviderConfig" };
+const CACHE_TTL_MS = 60_000;
+let cache: { value: GlobalAIProviderConfig; expiry: number } | null = null;
+
+export async function getGlobalAIConfig(): Promise<GlobalAIProviderConfig> {
+  if (cache && cache.expiry > Date.now()) return cache.value;
+  try {
+    const doc = await adminDb.collection(DOC_PATH.collection).doc(DOC_PATH.id).get();
+    const value = (doc.data() ?? {}) as GlobalAIProviderConfig;
+    cache = { value, expiry: Date.now() + CACHE_TTL_MS };
+    return value;
+  } catch (err) {
+    console.error("[Narada] getGlobalAIConfig failed:", err);
+    return {};
+  }
+}
+
+export function invalidateGlobalAIConfig(): void {
+  cache = null;
+}
+
+export type GlobalProviderKey = "claudeApi" | "gemini" | "groq" | "openai" | "azureOpenai";
+
+const PROVIDER_TO_GLOBAL: Record<KeyProvider, GlobalProviderKey> = {
+  "claude-api": "claudeApi",
+  gemini: "gemini",
+  groq: "groq",
+  openai: "openai",
+  "azure-openai": "azureOpenai",
+};
+
+export function globalKeyFor(provider: KeyProvider): GlobalProviderKey {
+  return PROVIDER_TO_GLOBAL[provider];
+}
+
+export function hasGlobalKey(
+  config: GlobalAIProviderConfig,
+  provider: KeyProvider
+): boolean {
+  const entry = config[globalKeyFor(provider)];
+  if (!entry) return false;
+  if (provider === "azure-openai") {
+    const c = entry as AzureOpenAIGlobalConfig;
+    return !!(c.apiKey && c.endpoint && c.deployment);
+  }
+  return !!(entry as SingleKeyGlobalConfig).apiKey;
+}
+
+export function globalKeyStatusFlags(
+  config: GlobalAIProviderConfig
+): Record<GlobalProviderKey, boolean> {
+  return {
+    claudeApi: hasGlobalKey(config, "claude-api"),
+    gemini: hasGlobalKey(config, "gemini"),
+    groq: hasGlobalKey(config, "groq"),
+    openai: hasGlobalKey(config, "openai"),
+    azureOpenai: hasGlobalKey(config, "azure-openai"),
+  };
+}
+
+const MASKED = "••••••••";
+
+function mask(value: string | undefined | null): string {
+  if (!value) return "";
+  if (value.length <= 8) return MASKED;
+  return value.slice(0, 4) + MASKED + value.slice(-4);
+}
+
+export function maskedGlobalConfig(config: GlobalAIProviderConfig) {
+  return {
+    claudeApi: config.claudeApi
+      ? { apiKey: mask(config.claudeApi.apiKey) }
+      : null,
+    gemini: config.gemini ? { apiKey: mask(config.gemini.apiKey) } : null,
+    groq: config.groq ? { apiKey: mask(config.groq.apiKey) } : null,
+    openai: config.openai
+      ? {
+          apiKey: mask(config.openai.apiKey),
+          model: config.openai.model ?? "",
+          baseUrl: config.openai.baseUrl ?? "",
+        }
+      : null,
+    azureOpenai: config.azureOpenai
+      ? {
+          apiKey: mask(config.azureOpenai.apiKey),
+          endpoint: config.azureOpenai.endpoint,
+          deployment: config.azureOpenai.deployment,
+          apiVersion: config.azureOpenai.apiVersion,
+        }
+      : null,
+    has: globalKeyStatusFlags(config),
+    updatedAt: config.updatedAt ?? null,
+    updatedBy: config.updatedBy ?? null,
+  };
+}
+
+export const GLOBAL_AI_DOC_REF = () =>
+  adminDb.collection(DOC_PATH.collection).doc(DOC_PATH.id);
+
+export const MASKED_PLACEHOLDER = MASKED;

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 import { authedFetch } from "@/lib/api-client";
 import { trackEvent } from "@/lib/analytics";
-import type { PlatformConfigData, AIProvider } from "@/types";
+import type { PlatformConfigData, AIProvider, KeyProvider } from "@/types";
+
+export type UseGlobalForMap = Partial<Record<KeyProvider, boolean>>;
 
 interface AIProviderSettings {
   aiProvider: AIProvider;
@@ -9,10 +11,81 @@ interface AIProviderSettings {
   claudeApiKey: string;
   deepgramApiKey: string;
   groqApiKey: string;
+  openaiApiKey: string;
+  azureOpenaiApiKey: string;
+  azureOpenaiEndpoint: string;
+  azureOpenaiDeployment: string;
+  azureOpenaiApiVersion: string;
   hasGeminiKey: boolean;
   hasClaudeKey: boolean;
   hasDeepgramKey: boolean;
   hasGroqKey: boolean;
+  hasOpenaiKey: boolean;
+  hasAzureOpenaiKey: boolean;
+  hasAzureOpenaiEndpoint: boolean;
+  hasAzureOpenaiDeployment: boolean;
+  useGlobalFor: UseGlobalForMap;
+}
+
+const EMPTY_AI_SETTINGS: AIProviderSettings = {
+  aiProvider: "local-claude",
+  geminiApiKey: "",
+  claudeApiKey: "",
+  deepgramApiKey: "",
+  groqApiKey: "",
+  openaiApiKey: "",
+  azureOpenaiApiKey: "",
+  azureOpenaiEndpoint: "",
+  azureOpenaiDeployment: "",
+  azureOpenaiApiVersion: "",
+  hasGeminiKey: false,
+  hasClaudeKey: false,
+  hasDeepgramKey: false,
+  hasGroqKey: false,
+  hasOpenaiKey: false,
+  hasAzureOpenaiKey: false,
+  hasAzureOpenaiEndpoint: false,
+  hasAzureOpenaiDeployment: false,
+  useGlobalFor: {},
+};
+
+function mapApiToSettings(data: Record<string, unknown>): AIProviderSettings {
+  return {
+    aiProvider: (data.aiProvider as AIProvider) ?? "local-claude",
+    geminiApiKey: (data.geminiApiKey as string) ?? "",
+    claudeApiKey: (data.claudeApiKey as string) ?? "",
+    deepgramApiKey: (data.deepgramApiKey as string) ?? "",
+    groqApiKey: (data.groqApiKey as string) ?? "",
+    openaiApiKey: (data.openaiApiKey as string) ?? "",
+    azureOpenaiApiKey: (data.azureOpenaiApiKey as string) ?? "",
+    azureOpenaiEndpoint: (data.azureOpenaiEndpoint as string) ?? "",
+    azureOpenaiDeployment: (data.azureOpenaiDeployment as string) ?? "",
+    azureOpenaiApiVersion: (data.azureOpenaiApiVersion as string) ?? "",
+    hasGeminiKey: !!data.hasGeminiKey,
+    hasClaudeKey: !!data.hasClaudeKey,
+    hasDeepgramKey: !!data.hasDeepgramKey,
+    hasGroqKey: !!data.hasGroqKey,
+    hasOpenaiKey: !!data.hasOpenaiKey,
+    hasAzureOpenaiKey: !!data.hasAzureOpenaiKey,
+    hasAzureOpenaiEndpoint: !!data.hasAzureOpenaiEndpoint,
+    hasAzureOpenaiDeployment: !!data.hasAzureOpenaiDeployment,
+    useGlobalFor: (data.useGlobalFor as UseGlobalForMap) ?? {},
+  };
+}
+
+export interface SaveAIProviderPayload {
+  aiProvider: AIProvider;
+  geminiApiKey?: string;
+  claudeApiKey?: string;
+  deepgramApiKey?: string;
+  groqApiKey?: string;
+  openaiApiKey?: string;
+  azureOpenaiApiKey?: string;
+  azureOpenaiEndpoint?: string;
+  azureOpenaiDeployment?: string;
+  azureOpenaiApiVersion?: string;
+  useGlobalFor?: UseGlobalForMap;
+  removeKeys?: string[];
 }
 
 interface SettingsStore {
@@ -28,14 +101,11 @@ interface SettingsStore {
   aiLoading: boolean;
   aiError: boolean;
   fetchAIProviderSettings: () => Promise<void>;
-  saveAIProviderSettings: (data: {
-    aiProvider: AIProvider;
-    geminiApiKey?: string;
-    claudeApiKey?: string;
-    deepgramApiKey?: string;
-    groqApiKey?: string;
-    removeKeys?: string[];
-  }) => Promise<void>;
+  saveAIProviderSettings: (data: SaveAIProviderPayload) => Promise<void>;
+
+  // Global AI status (read-only — set by admin)
+  globalAIStatus: Record<string, boolean>;
+  fetchGlobalAIStatus: () => Promise<void>;
 }
 
 export const useSettingsStore = create<SettingsStore>((set) => ({
@@ -86,17 +156,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
   },
 
   // AI provider
-  aiSettings: {
-    aiProvider: "local-claude",
-    geminiApiKey: "",
-    claudeApiKey: "",
-    deepgramApiKey: "",
-    groqApiKey: "",
-    hasGeminiKey: false,
-    hasClaudeKey: false,
-    hasDeepgramKey: false,
-    hasGroqKey: false,
-  },
+  aiSettings: EMPTY_AI_SETTINGS,
   aiLoading: false,
   aiError: false,
 
@@ -106,20 +166,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
       const res = await authedFetch("/api/settings/ai-provider");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      set({
-        aiLoading: false,
-        aiSettings: {
-          aiProvider: data.aiProvider ?? "local-claude",
-          geminiApiKey: data.geminiApiKey ?? "",
-          claudeApiKey: data.claudeApiKey ?? "",
-          deepgramApiKey: data.deepgramApiKey ?? "",
-          groqApiKey: data.groqApiKey ?? "",
-          hasGeminiKey: data.hasGeminiKey ?? false,
-          hasClaudeKey: data.hasClaudeKey ?? false,
-          hasDeepgramKey: data.hasDeepgramKey ?? false,
-          hasGroqKey: data.hasGroqKey ?? false,
-        },
-      });
+      set({ aiLoading: false, aiSettings: mapApiToSettings(data) });
     } catch (err) {
       console.error("[Narada] fetchAIProviderSettings:", err);
       set({ aiError: true, aiLoading: false });
@@ -135,22 +182,22 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
         body: JSON.stringify(data),
       });
       const updated = await res.json();
-      set({
-        aiSettings: {
-          aiProvider: updated.aiProvider ?? "local-claude",
-          geminiApiKey: updated.geminiApiKey ?? "",
-          claudeApiKey: updated.claudeApiKey ?? "",
-          deepgramApiKey: updated.deepgramApiKey ?? "",
-          groqApiKey: updated.groqApiKey ?? "",
-          hasGeminiKey: updated.hasGeminiKey ?? false,
-          hasClaudeKey: updated.hasClaudeKey ?? false,
-          hasDeepgramKey: updated.hasDeepgramKey ?? false,
-          hasGroqKey: updated.hasGroqKey ?? false,
-        },
-      });
+      set({ aiSettings: mapApiToSettings(updated) });
     } catch (err) {
       console.error("[Narada] saveAIProviderSettings:", err);
       throw err;
+    }
+  },
+
+  globalAIStatus: {},
+  fetchGlobalAIStatus: async () => {
+    try {
+      const res = await authedFetch("/api/settings/global-ai-status");
+      if (!res.ok) return;
+      const data = await res.json();
+      set({ globalAIStatus: data as Record<string, boolean> });
+    } catch (err) {
+      console.error("[Narada] fetchGlobalAIStatus:", err);
     }
   },
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,8 @@
-export type AIProvider = "gemini" | "claude-api" | "local-claude" | "local-cursor" | "groq";
+export type AIProvider = "gemini" | "claude-api" | "local-claude" | "local-cursor" | "groq" | "openai" | "azure-openai";
+
+export type KeyProvider = Exclude<AIProvider, "local-claude" | "local-cursor">;
+
+export const KEY_PROVIDERS: KeyProvider[] = ["gemini", "claude-api", "groq", "openai", "azure-openai"];
 
 export type PublishStatus = "PENDING" | "SENT" | "FAILED" | "SKIPPED";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7451,6 +7451,11 @@ open@^11.0.0:
     powershell-utils "^0.1.0"
     wsl-utils "^0.3.0"
 
+openai@^6.39.1:
+  version "6.39.1"
+  resolved "https://registry.npmjs.org/openai/-/openai-6.39.1.tgz"
+  integrity sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz"
@@ -9572,7 +9577,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.17.0:
+ws@^8.17.0, ws@^8.18.0:
   version "8.19.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==


### PR DESCRIPTION
## Summary
- Adds **OpenAI** and **Azure OpenAI** as AI provider options alongside the existing Local Claude / Local Cursor / Gemini / Claude API / Groq.
- Introduces a new admin-only **Sacred Sanctum** page (`/admin/settings`) where admins can bestow global API keys for any key-requiring provider. The global config is stored once at `config/aiProviderConfig` in Firestore and pulled at runtime (60s cache).
- Each devotee gets a per-provider **"Use the global oracle"** toggle in Divine Oracle. Personal keys take precedence by default; if a user has no personal key, the resolver falls back to the global config when available.
- All provider invocations (parse, test, Jira issue enrichment) now go through a single `resolveProviderConfig` helper so global-vs-personal behavior is identical everywhere.

## Why
Org-licensed Azure OpenAI access is centralized — one team key shared by many devotees — so it doesn't make sense to make every devotee paste it locally. This also generalizes to any provider where an admin wants to bestow a shared key.

## What changed

**New providers**
- `src/lib/ai/openai-provider.ts` — `OpenAIProvider` + `AzureOpenAIProvider` using the `openai` SDK with `response_format: json_object` and `max_completion_tokens` (required for newer Azure deployments — `max_tokens` is rejected on `gpt-4o-2024-08-06+` / `gpt-5.x`).

**Global config layer**
- `src/lib/global-ai-config.ts` — cached loader + masking helpers for `config/aiProviderConfig`.
- `src/app/api/admin/config/ai-provider/route.ts` (GET/PUT, `verifyAdmin`) — masked responses, partial per-provider updates, supports removing providers.
- `src/app/api/settings/global-ai-status/route.ts` — authenticated booleans only, no secrets — used by the Divine Oracle card to show whether the global toggle is meaningful.

**Resolver + factory**
- `src/lib/ai/index.ts` — new `resolveProviderConfig(provider, settings, global)`. Order: if `useGlobalFor[provider]===true` try global first; otherwise personal first, then fall back to the other side. Throws a Narad-voice error pointing at Sacred Configurations / the high priest when neither is set.
- `src/app/api/settings/ai-provider/route.ts` — adds OpenAI + Azure fields and the `useGlobalFor` map; per-provider merge on PUT.
- `src/app/api/settings/test-ai/route.ts` — rewritten to **always merge stored Firestore values with form body** so Test works even when the masked key isn't re-typed.
- `src/lib/ai/enrich-issue.ts` — now uses the resolver so Jira issue enrichment supports groq / openai / azure-openai (groq previously threw "Unknown AI provider") and honors `useGlobalFor`.

**UI**
- `src/components/settings/ai-provider-card.tsx` — new providers + per-provider "Use the global oracle" toggle + Azure endpoint/deployment/apiVersion inputs + global-availability hint.
- `src/components/admin/global-ai-oracle-card.tsx` — admin card with per-provider inscribe/remove for all five key providers.
- `src/components/admin/admin-settings-client.tsx` + `src/app/admin/settings/page.tsx` + sidebar entry — new admin-only "Sacred Sanctum" route with `ShieldCheck` icon; admin link only renders when `isAdmin`.
- `src/stores/settings-store.ts` — extended `AIProviderSettings` and `globalAIStatus`/`fetchGlobalAIStatus`.
- `src/components/update/step-processing.tsx` — adds processing labels for the new providers.

## Test plan
- [ ] Sign in as a non-admin → Settings → Divine Oracle. Pick **OpenAI**: paste a key, save, click **Test** — succeeds.
- [ ] Pick **Azure OpenAI**: paste key + endpoint + deployment + apiVersion, save, click Test — succeeds (verified working with `gpt-5.5-2` deployment on `2024-08-01-preview`).
- [ ] Switch active provider to Claude API / Gemini / Groq, click Test — still succeeds (no regression).
- [ ] Add your UID to Firestore `app/admins`, reload — **Sacred Sanctum** link appears in sidebar; **Observatory** still shows analytics only (no Global AI Oracle there anymore).
- [ ] In Sacred Sanctum, inscribe a global Claude API key. Devotools `/api/settings/global-ai-status` returns `claudeApi: true`.
- [ ] Back in Divine Oracle (any user): Claude API now shows "high priest has set a global oracle." Toggle **Use the global oracle** ON, save, run a parse via `/update?date=...` — succeeds using the global key.
- [ ] Toggle OFF, paste a personal key — personal key takes precedence on the next parse.
- [ ] Repeat the global-vs-personal flow for OpenAI and Azure OpenAI.
- [ ] Try **Report issue** (Jira issue enrichment) with each cloud provider selected — all five now work (groq + openai + azure-openai were previously broken here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)