### PR TITLE
feat: "Fetch from Last Update" to pre-fill the day's input

### DIFF
--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -378,6 +378,31 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ update: { id: doc.id, ...doc.data() } });
     }
 
+    // Most recent *non-empty* update strictly before a given day — for
+    // "fetch from last update". Walks back past empty days (weekends, leave,
+    // or blank entries) to the last day that actually has content to reuse.
+    const latest = searchParams.get("latest");
+    if (latest) {
+      const before = searchParams.get("before"); // YYYY-MM-DD
+      let latestQuery: Query = updatesCol(user.uid).orderBy("date", "desc");
+      if (before) {
+        const beforeIso = new Date(`${before}T00:00:00.000Z`).toISOString();
+        latestQuery = updatesCol(user.uid)
+          .where("date", "<", beforeIso)
+          .orderBy("date", "desc");
+      }
+      // Scan recent updates newest-first; return the first with reusable
+      // content — either spoken/written words or logged work.
+      const snap = await latestQuery.limit(60).get();
+      const doc = snap.docs.find((d: QueryDocumentSnapshot) => {
+        const data = d.data();
+        const hasText = typeof data.rawTranscript === "string" && data.rawTranscript.trim().length > 0;
+        const hasLogs = Array.isArray(data.workLogEntries) && data.workLogEntries.length > 0;
+        return hasText || hasLogs;
+      });
+      return NextResponse.json({ update: doc ? { id: doc.id, ...doc.data() } : null });
+    }
+
     // List updates by month
     const month = searchParams.get("month");
     let query: Query = updatesCol(user.uid).orderBy("date", "desc");

--- a/src/components/update/input-section.tsx
+++ b/src/components/update/input-section.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { useUpdateStore } from "@/stores/update-store";
+import { useAppStore } from "@/stores/app-store";
 import { useToastStore } from "@/components/ui/toast";
 import { authedFetch } from "@/lib/api-client";
 import { Button } from "@/components/ui/button";
 import { useAudioRecorder } from "@/hooks/use-audio-recorder";
 import { AudioVisualizer } from "./audio-visualizer";
-import { Mic, Square, Loader2, Zap, RotateCcw } from "lucide-react";
+import { Mic, Square, Loader2, Zap, RotateCcw, History } from "lucide-react";
 
 interface InputSectionProps {
   onProcess: () => void;
@@ -28,8 +29,10 @@ export function InputSection({ onProcess }: InputSectionProps) {
     setAudioBlob,
   } = useUpdateStore();
   const { toggleRecording, startRecording } = useAudioRecorder();
+  const selectedDate = useAppStore((s) => s.selectedDate);
 
   const [hasDeepgramKey, setHasDeepgramKey] = useState<boolean | null>(null);
+  const [isFetchingLast, setIsFetchingLast] = useState(false);
   useEffect(() => {
     authedFetch("/api/settings/ai-provider")
       .then((r) => r.json())
@@ -86,13 +89,60 @@ export function InputSection({ onProcess }: InputSectionProps) {
     startRecording();
   };
 
+  const handleFetchLast = async () => {
+    if (isFetchingLast || isProcessing || isTranscribing) return;
+    setIsFetchingLast(true);
+    try {
+      const dateStr = selectedDate
+        ? selectedDate.toLocaleDateString("sv-SE")
+        : new Date().toLocaleDateString("sv-SE");
+      const res = await authedFetch(`/api/updates?latest=true&before=${dateStr}`);
+      if (!res.ok) throw new Error("request failed");
+      const { update } = await res.json();
+      const prior = (update?.rawTranscript ?? "").trim();
+      if (!prior) {
+        useToastStore
+          .getState()
+          .addToast("Alas! No prior chronicle to draw upon", "warning");
+        return;
+      }
+      setRawTranscript(prior);
+      useToastStore
+        .getState()
+        .addToast("Narayan Narayan! Your last words return — edit, then invoke the sage", "success");
+    } catch {
+      useToastStore
+        .getState()
+        .addToast("Alas! The last chronicle eluded my grasp", "error");
+    } finally {
+      setIsFetchingLast(false);
+    }
+  };
+
   const hasText = rawTranscript.trim().length > 0;
 
   return (
     <div className="flex flex-col h-full pb-6">
-      {/* Section label */}
-      <div className="text-xs font-semibold text-narada-text-secondary uppercase tracking-wider mb-4">
-        Your Words
+      {/* Section label + fetch-from-last action */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-xs font-semibold text-narada-text-secondary uppercase tracking-wider">
+          Your Words
+        </div>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={handleFetchLast}
+          disabled={isFetchingLast || isProcessing || isTranscribing}
+          className="text-narada-text-muted"
+          title="Pre-fill with your last update's words"
+        >
+          {isFetchingLast ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <History className="w-3.5 h-3.5" />
+          )}
+          <span>Fetch from Last Update</span>
+        </Button>
       </div>
 
       {/* Textarea — at top, fills available space */}


### PR DESCRIPTION
## What

Adds a **Fetch from Last Update** button to the update input panel ("Your Words"). Clicking it pulls the most recent prior update's transcript into the text box, so users can reuse and tweak yesterday's words instead of starting from scratch — most days people work on similar tickets.

## Why

People often log similar work day-to-day. Re-typing or re-dictating the same tickets is tedious. This lets you pull your last update as a starting point, edit it, then invoke the sage as normal.

## How

- **API** — New `GET /api/updates?latest=true&before=YYYY-MM-DD` mode returns the most recent update strictly *before* the given day. It scans up to 60 updates newest-first and skips empty days (weekends, leave, blanks), landing on the last day that actually has reusable content (text or work logs).
- **UI** — The input section ("Your Words") gains a "Fetch from Last Update" action in the header. It pre-fills the transcript text box, available immediately on opening a day — before recording or processing. Sage-voiced toasts for success / no-prior / error.

## Notes

- The fetch **overwrites** whatever is currently typed (explicit, intentional click).
- Source is the **raw transcript**, not the parsed Jira table — that's what feeds back into the editable text box.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean on changed files
- [ ] Manual: open a day, click Fetch, confirm last update's words appear; verify weekend/leave gaps are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)