### PR TITLE
ci: bump release workflow actions to Node 24 runtime majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             platform: mac
             build_args: --mac --arm64 --x64
             artifact: narada-mac
-          - os: windows-latest
+          - os: windows-2025
             platform: win
             build_args: --win --x64
             artifact: narada-win-x64
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -80,7 +80,7 @@ jobs:
         run: npx electron-builder ${{ matrix.build_args }} --publish never
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: |
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -107,7 +107,7 @@ jobs:
         run: find artifacts -type f | head -30
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## What

Upgrades all GitHub Actions in `.github/workflows/release.yml` to their latest majors, all of which run on the **node24** runtime — clearing the Node.js 20 action deprecation warnings emitted during the v1.12.0 release.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

Also pins the Windows runner `windows-latest` → `windows-2025` to avoid the surprise image migration GitHub flagged.

## Why

- **Node 20 actions deprecated:** runners force Node 24 on **June 2 2026**; Node 20 removed **Sept 16 2026**. Latest majors verified to use `using: node24`.
- `upload-artifact@v7` and `download-artifact@v8` share the post-v4 backend and stay cross-compatible.

## Notes

- Build `node-version` stays at **20** — the warnings were about the action runtime, not the project's build Node. Bumping the build to Node 24 is a separate, riskier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)